### PR TITLE
Ultra code review v2 — segurança (RLS/pagamentos), correção, performance, a11y

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,9 @@ VITE_APP_NAME=Resultadismo
 
 # Web Push (opcional) — chave pública VAPID. Gere com: npx web-push generate-vapid-keys
 VITE_VAPID_PUBLIC_KEY=
+
+# Login de desenvolvimento (APENAS dev) — habilita o botão "Entrar como João (dev)".
+# O botão só aparece quando ambas estão preenchidas E o app roda em modo dev.
+# Nunca defina em produção.
+# VITE_DEV_LOGIN_EMAIL=
+# VITE_DEV_LOGIN_PASSWORD=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# Resultadismo — contexto do projeto (para agentes)
+
+Jogo de palpites de futebol. **Não usa Trigger.dev** (qualquer instrução global de
+Trigger.dev não se aplica aqui). A stack real:
+
+- **Front:** React 19 + TypeScript + Vite + Tailwind v4 + TanStack Query + React Router. PWA (vite-plugin-pwa).
+- **Backend:** Supabase — Postgres (RLS + RPCs `SECURITY DEFINER`), Edge Functions (Deno), Auth (Google OAuth).
+- **Tarefas agendadas:** `pg_cron` no Postgres + Edge Functions (NÃO Trigger.dev).
+- **Pagamentos:** Mercado Pago (Pix) para federações pagas.
+
+## Deploy (importante)
+
+- **Push para `main` aplica migrations em PRODUÇÃO** (integração GitHub↔Supabase) e
+  faz deploy das Edge Functions (`.github/workflows/deploy-functions.yml`). O Vercel
+  publica o front. Ou seja: mergear na `main` = deploy em prod.
+- **NUNCA rodar `supabase db push`/`db reset` apontando para prod.** Use só o stack local.
+
+## Desenvolvimento local
+
+- `npm run dev` (Vite) + `supabase start` (stack local).
+- Banco local nas portas 5442x (não colidir com outros projetos).
+- `npm run db:reset` aplica migrations + seed no banco LOCAL.
+- `npm run db:types` regenera `src/types/database.ts` a partir do schema local.
+- `npm run build` = `tsc -b && vite build`. `npm run lint` = ESLint. `npm run typecheck`.
+
+## Convenções
+
+- Autorização é SEMPRE no servidor (RLS + RPCs definer). Gating no client é cosmético.
+- Erros do Supabase: `PostgrestError` não é `instanceof Error` — converta com
+  `throw new Error(error.message)` nos hooks de dados.
+- Edge Functions compartilham CORS/util em `supabase/functions/_shared/`.
+- Escudos/flâmulas: string `crest:` (ver `src/lib/crest.ts`). Foto é sanitizada antes do CSS.
+- Semana do Joker é ancorada em `America/Sao_Paulo` (BRT) no servidor.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,26 @@
+import js from "@eslint/js";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+
+export default tseslint.config(
+  // Pastas/arquivos que o lint não deve analisar.
+  {
+    ignores: ["dist/", "dev-dist/", "supabase/", "**/*.config.*"],
+  },
+  // Base: JS + TypeScript recomendados, hooks e react-refresh (preset Vite).
+  {
+    files: ["**/*.{ts,tsx}"],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommended,
+      reactHooks.configs.flat["recommended-latest"],
+      reactRefresh.configs.vite,
+    ],
+    languageOptions: {
+      ecmaVersion: 2022,
+      globals: globals.browser,
+    },
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,13 +19,19 @@
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.4",
         "@tailwindcss/vite": "^4.3.0",
         "@types/node": "^25.9.1",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
+        "eslint": "^9.39.4",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "eslint-plugin-react-refresh": "^0.5.2",
+        "globals": "^17.6.0",
         "tailwindcss": "^4.3.0",
         "typescript": "^6.0.3",
+        "typescript-eslint": "^8.60.1",
         "vite": "^8.0.14",
         "vite-plugin-pwa": "^1.3.0",
         "workbox-precaching": "^7.4.1"
@@ -1624,6 +1630,315 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
@@ -2874,6 +3189,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
@@ -2918,6 +3240,262 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
+      "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/type-utils": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.60.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
+      "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
+      "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.60.1",
+        "@typescript-eslint/types": "^8.60.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
+      "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
+      "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
+      "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
+      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
+      "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.60.1",
+        "@typescript-eslint/tsconfig-utils": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
+      "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
+      "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.60.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
@@ -2957,6 +3535,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -2973,6 +3561,29 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -3225,6 +3836,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001793",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
@@ -3246,6 +3867,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -3254,6 +3892,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -3271,6 +3929,13 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -3415,6 +4080,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -3670,6 +4342,248 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.2.tgz",
+      "integrity": "sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -3714,6 +4628,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -3747,6 +4668,19 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/filelist": {
@@ -3788,6 +4722,44 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -4003,6 +4975,32 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -4051,6 +5049,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-property-descriptors": {
@@ -4124,6 +5132,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
@@ -4139,6 +5164,43 @@
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -4290,6 +5352,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
@@ -4324,6 +5396,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-map": {
@@ -4619,6 +5704,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -4632,10 +5740,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4675,6 +5797,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4683,6 +5815,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lightningcss": {
@@ -4946,10 +6092,33 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5051,6 +6220,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.46",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
@@ -5105,6 +6281,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -5123,12 +6317,67 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -5231,6 +6480,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/pretty-bytes": {
@@ -5447,6 +6706,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/rolldown": {
@@ -5964,6 +7233,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -6083,11 +7378,37 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-fest": {
       "version": "0.16.0",
@@ -6192,6 +7513,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
+      "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.60.1",
+        "@typescript-eslint/parser": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -6327,6 +7672,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/vite": {
@@ -6562,6 +7917,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/workbox-background-sync": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.4.1.tgz",
@@ -6788,6 +8153,42 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,13 +27,19 @@
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
     "@tailwindcss/vite": "^4.3.0",
     "@types/node": "^25.9.1",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
+    "eslint": "^9.39.4",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-react-refresh": "^0.5.2",
+    "globals": "^17.6.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
+    "typescript-eslint": "^8.60.1",
     "vite": "^8.0.14",
     "vite-plugin-pwa": "^1.3.0",
     "workbox-precaching": "^7.4.1"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,27 @@
+import { lazy, Suspense } from "react";
 import { Routes, Route, Navigate, useParams } from "react-router-dom";
 import { RequireAuth, RequireAdmin } from "@/features/auth/guards";
 import { LoginPage } from "@/features/auth/LoginPage";
 import { AuthCallback } from "@/features/auth/AuthCallback";
 import { AppShell } from "@/components/layout/AppShell";
 import { JogosPage } from "@/features/matches/JogosPage";
-import { PerfilPage } from "@/features/profile/PerfilPage";
-import { LigasPage } from "@/features/leagues/LigasPage";
-import { NovaLigaPage } from "@/features/leagues/NovaLigaPage";
-import { LigaDetailPage } from "@/features/leagues/LigaDetailPage";
-import { EditarPerfilPage } from "@/features/profile/EditarPerfilPage";
-import { AdminPage } from "@/features/admin/AdminPage";
-import { AdminCompMatchesPage } from "@/features/admin/AdminCompMatchesPage";
-import { PlayerProfilePage } from "@/features/players/PlayerProfilePage";
-import { ComoFuncionaPage } from "@/features/help/ComoFuncionaPage";
 import { Onboarding } from "@/features/onboarding/Onboarding";
-import { PrivacidadePage } from "@/features/legal/PrivacidadePage";
-import { TermosPage } from "@/features/legal/TermosPage";
-import { SimuladorPage } from "@/features/confronto/SimuladorPage";
+
+// Code-splitting: o primeiro paint (landing de Jogos + login) não baixa admin,
+// confronto/simulador, editor de perfil nem páginas secundárias — elas carregam
+// sob demanda. Corta um bom pedaço do bundle inicial.
+const PerfilPage = lazy(() => import("@/features/profile/PerfilPage").then((m) => ({ default: m.PerfilPage })));
+const LigasPage = lazy(() => import("@/features/leagues/LigasPage").then((m) => ({ default: m.LigasPage })));
+const NovaLigaPage = lazy(() => import("@/features/leagues/NovaLigaPage").then((m) => ({ default: m.NovaLigaPage })));
+const LigaDetailPage = lazy(() => import("@/features/leagues/LigaDetailPage").then((m) => ({ default: m.LigaDetailPage })));
+const EditarPerfilPage = lazy(() => import("@/features/profile/EditarPerfilPage").then((m) => ({ default: m.EditarPerfilPage })));
+const AdminPage = lazy(() => import("@/features/admin/AdminPage").then((m) => ({ default: m.AdminPage })));
+const AdminCompMatchesPage = lazy(() => import("@/features/admin/AdminCompMatchesPage").then((m) => ({ default: m.AdminCompMatchesPage })));
+const PlayerProfilePage = lazy(() => import("@/features/players/PlayerProfilePage").then((m) => ({ default: m.PlayerProfilePage })));
+const ComoFuncionaPage = lazy(() => import("@/features/help/ComoFuncionaPage").then((m) => ({ default: m.ComoFuncionaPage })));
+const PrivacidadePage = lazy(() => import("@/features/legal/PrivacidadePage").then((m) => ({ default: m.PrivacidadePage })));
+const TermosPage = lazy(() => import("@/features/legal/TermosPage").then((m) => ({ default: m.TermosPage })));
+const SimuladorPage = lazy(() => import("@/features/confronto/SimuladorPage").then((m) => ({ default: m.SimuladorPage })));
 
 // Redireciona links antigos /ligas/:slug para /federacoes/:slug (rename Liga -> Federação)
 function FederacaoSlugRedirect() {
@@ -24,47 +29,57 @@ function FederacaoSlugRedirect() {
   return <Navigate to={`/federacoes/${slug ?? ""}`} replace />;
 }
 
+function PageFallback() {
+  return (
+    <div className="flex min-h-[40vh] items-center justify-center p-8 text-sm opacity-60">
+      Carregando…
+    </div>
+  );
+}
+
 export default function App() {
   return (
     <>
       <Onboarding />
-      <Routes>
-      <Route path="/login" element={<LoginPage />} />
-      <Route path="/auth/callback" element={<AuthCallback />} />
+      <Suspense fallback={<PageFallback />}>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/auth/callback" element={<AuthCallback />} />
 
-      {/* públicas e sempre acessíveis (Google exige links públicos) */}
-      <Route path="/privacidade" element={<PrivacidadePage />} />
-      <Route path="/termos" element={<TermosPage />} />
+          {/* públicas e sempre acessíveis (Google exige links públicos) */}
+          <Route path="/privacidade" element={<PrivacidadePage />} />
+          <Route path="/termos" element={<TermosPage />} />
 
-      {/* compat: links antigos de "liga" agora apontam para "federação" */}
-      <Route path="/ligas" element={<Navigate to="/federacoes" replace />} />
-      <Route path="/ligas/nova" element={<Navigate to="/federacoes/nova" replace />} />
-      <Route path="/ligas/:slug" element={<FederacaoSlugRedirect />} />
+          {/* compat: links antigos de "liga" agora apontam para "federação" */}
+          <Route path="/ligas" element={<Navigate to="/federacoes" replace />} />
+          <Route path="/ligas/nova" element={<Navigate to="/federacoes/nova" replace />} />
+          <Route path="/ligas/:slug" element={<FederacaoSlugRedirect />} />
 
-      <Route element={<AppShell />}>
-        {/* público: ver jogos sem login */}
-        <Route path="/" element={<JogosPage />} />
-        <Route path="/como-funciona" element={<ComoFuncionaPage />} />
+          <Route element={<AppShell />}>
+            {/* público: ver jogos sem login */}
+            <Route path="/" element={<JogosPage />} />
+            <Route path="/como-funciona" element={<ComoFuncionaPage />} />
 
-        {/* exige login */}
-        <Route element={<RequireAuth />}>
-          <Route path="/federacoes" element={<LigasPage />} />
-          <Route path="/federacoes/nova" element={<NovaLigaPage />} />
-          <Route path="/federacoes/:slug" element={<LigaDetailPage />} />
-          <Route path="/classificacao" element={<Navigate to="/federacoes" replace />} />
-          <Route path="/perfil" element={<PerfilPage />} />
-          <Route path="/perfil/editar" element={<EditarPerfilPage />} />
-          <Route path="/simulador" element={<SimuladorPage />} />
-          <Route path="/jogador/:id" element={<PlayerProfilePage />} />
-          <Route element={<RequireAdmin />}>
-            <Route path="/admin" element={<AdminPage />} />
-            <Route path="/admin/competicoes/:id/jogos" element={<AdminCompMatchesPage />} />
+            {/* exige login */}
+            <Route element={<RequireAuth />}>
+              <Route path="/federacoes" element={<LigasPage />} />
+              <Route path="/federacoes/nova" element={<NovaLigaPage />} />
+              <Route path="/federacoes/:slug" element={<LigaDetailPage />} />
+              <Route path="/classificacao" element={<Navigate to="/federacoes" replace />} />
+              <Route path="/perfil" element={<PerfilPage />} />
+              <Route path="/perfil/editar" element={<EditarPerfilPage />} />
+              <Route path="/simulador" element={<SimuladorPage />} />
+              <Route path="/jogador/:id" element={<PlayerProfilePage />} />
+              <Route element={<RequireAdmin />}>
+                <Route path="/admin" element={<AdminPage />} />
+                <Route path="/admin/competicoes/:id/jogos" element={<AdminCompMatchesPage />} />
+              </Route>
+            </Route>
           </Route>
-        </Route>
-      </Route>
 
-      <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </Suspense>
     </>
   );
 }

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { legacyToCrest } from "@/lib/crest";
 import { CrestMask } from "./CrestMask";
 
@@ -26,9 +27,10 @@ export function Avatar({
   size?: Size;
   className?: string;
 }) {
+  const crest = useMemo(() => legacyToCrest(src), [src]);
   return (
     <CrestMask
-      src={legacyToCrest(src)}
+      src={crest}
       name={name}
       px={px[size]}
       defaultKind="escudo"

--- a/src/components/ui/CrestMask.tsx
+++ b/src/components/ui/CrestMask.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import {
   type CrestKind,
@@ -24,50 +25,57 @@ export type CrestMaskProps = {
   className?: string;
 };
 
-export function CrestMask({
+const CrestMaskBase = ({
   src,
   name,
   px,
   defaultKind = "escudo",
   withLetter = false,
   className,
-}: CrestMaskProps) {
-  const cfg = parseCrest(src) ?? defaultCrestFromName(name, defaultKind);
-  const maskUrl = crestShapeUrl(cfg.kind, cfg.shape);
-  const bg = crestBackground(cfg);
+}: CrestMaskProps) => {
+  const { maskStyle, showLetter, initial, fontSize, textColor, textShadow } = useMemo(() => {
+    const cfg = parseCrest(src) ?? defaultCrestFromName(name, defaultKind);
+    const maskUrl = crestShapeUrl(cfg.kind, cfg.shape);
+    const bg = crestBackground(cfg);
 
-  // letra só aparece quando NÃO há foto de verdade exibida
-  const hasPhoto = cfg.fill === "photo" && !!cfg.photo;
-  const showLetter = withLetter && !hasPhoto;
-  const initial = (name?.trim()?.[0] ?? "?").toUpperCase();
+    // letra só aparece quando NÃO há foto de verdade exibida
+    const hasPhoto = cfg.fill === "photo" && !!cfg.photo;
 
-  // Inicial proporcional ao escudo: ~30px no preview grande (80px) e escala
-  // junto nos tamanhos menores. Peso 800. Centralizada.
-  const fontSize = Math.round(px * 0.375);
+    // mask-mode: alpha → usa o canal alfa do SVG (área pintada = opaca = mostra o
+    // fundo; fora do desenho = transparente). Assim a cor do traço no SVG não
+    // importa, só a silhueta. WebKit já usa alpha por padrão.
+    // Sem máscara (pasta de formas vazia) → cai num círculo simples, sem virar
+    // um quadrado de cor cheio.
+    const maskStyle = maskUrl
+      ? ({
+          background: bg,
+          WebkitMaskImage: `url("${maskUrl}")`,
+          maskImage: `url("${maskUrl}")`,
+          maskMode: "alpha",
+          WebkitMaskRepeat: "no-repeat",
+          maskRepeat: "no-repeat",
+          WebkitMaskPosition: "center",
+          maskPosition: "center",
+          WebkitMaskSize: "contain",
+          maskSize: "contain",
+          // drop-shadow segue o recorte do SVG: dá uma borda fina + leve elevação,
+          // pra um escudo claro (gelo/branco) não sumir no fundo claro.
+          filter:
+            "drop-shadow(0 0 0.5px rgba(12,22,22,0.35)) drop-shadow(0 1px 1.5px rgba(12,22,22,0.18))",
+        } as const)
+      : ({ background: bg, borderRadius: "9999px" } as const);
 
-  // mask-mode: alpha → usa o canal alfa do SVG (área pintada = opaca = mostra o
-  // fundo; fora do desenho = transparente). Assim a cor do traço no SVG não
-  // importa, só a silhueta. WebKit já usa alpha por padrão.
-  // Sem máscara (pasta de formas vazia) → cai num círculo simples, sem virar
-  // um quadrado de cor cheio.
-  const maskStyle = maskUrl
-    ? ({
-        background: bg,
-        WebkitMaskImage: `url("${maskUrl}")`,
-        maskImage: `url("${maskUrl}")`,
-        maskMode: "alpha",
-        WebkitMaskRepeat: "no-repeat",
-        maskRepeat: "no-repeat",
-        WebkitMaskPosition: "center",
-        maskPosition: "center",
-        WebkitMaskSize: "contain",
-        maskSize: "contain",
-        // drop-shadow segue o recorte do SVG: dá uma borda fina + leve elevação,
-        // pra um escudo claro (gelo/branco) não sumir no fundo claro.
-        filter:
-          "drop-shadow(0 0 0.5px rgba(12,22,22,0.35)) drop-shadow(0 1px 1.5px rgba(12,22,22,0.18))",
-      } as const)
-    : ({ background: bg, borderRadius: "9999px" } as const);
+    return {
+      maskStyle,
+      showLetter: withLetter && !hasPhoto,
+      initial: (name?.trim()?.[0] ?? "?").toUpperCase(),
+      // Inicial proporcional ao escudo: ~30px no preview grande (80px) e escala
+      // junto nos tamanhos menores. Peso 800. Centralizada.
+      fontSize: Math.round(px * 0.375),
+      textColor: crestTextColor(cfg),
+      textShadow: cfg.fill === "solid" ? undefined : "0 1px 3px rgba(0,0,0,0.4)",
+    };
+  }, [src, name, px, defaultKind, withLetter]);
 
   return (
     <span
@@ -80,10 +88,10 @@ export function CrestMask({
         <span
           className="absolute inset-0 grid place-items-center leading-none"
           style={{
-            color: crestTextColor(cfg),
+            color: textColor,
             fontWeight: 800,
             fontSize,
-            textShadow: cfg.fill === "solid" ? undefined : "0 1px 3px rgba(0,0,0,0.4)",
+            textShadow,
           }}
         >
           {initial}
@@ -91,4 +99,6 @@ export function CrestMask({
       )}
     </span>
   );
-}
+};
+
+export const CrestMask = memo(CrestMaskBase);

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,4 +1,4 @@
-import { type InputHTMLAttributes, forwardRef, type ReactNode } from "react";
+import { type InputHTMLAttributes, forwardRef, type ReactNode, useId } from "react";
 import { cn } from "@/lib/utils";
 
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -11,10 +11,12 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
   { className, icon, error, label, id, ...props },
   ref,
 ) {
+  const reactId = useId();
+  const inputId = id ?? reactId;
   return (
     <div className="flex w-full flex-col gap-1.5">
       {label && (
-        <label htmlFor={id} className="text-sm font-medium text-ink-800">
+        <label htmlFor={inputId} className="text-sm font-medium text-ink-800">
           {label}
         </label>
       )}
@@ -28,7 +30,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
         {icon && <span className="shrink-0 text-ink-400">{icon}</span>}
         <input
           ref={ref}
-          id={id}
+          id={inputId}
           className={cn(
             "h-11 w-full bg-transparent text-ink-950 outline-none placeholder:text-ink-400",
             className,

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -50,13 +50,20 @@ export function ToastProvider({ children }: { children: ReactNode }) {
         {toasts.map((t) => (
           <div
             key={t.id}
+            role={t.tone === "error" ? "alert" : "status"}
+            aria-live={t.tone === "error" ? "assertive" : "polite"}
+            aria-atomic="true"
             className={cn(
               "animate-pop-in pointer-events-auto flex w-full max-w-sm items-center gap-3 rounded-md bg-surface p-3 shadow-[var(--shadow-pop)] ring-1 ring-border",
             )}
           >
             {icons[t.tone]}
             <p className="flex-1 text-sm font-medium text-ink-900">{t.message}</p>
-            <button onClick={() => remove(t.id)} className="text-ink-400 hover:text-ink-700">
+            <button
+              onClick={() => remove(t.id)}
+              aria-label="Fechar"
+              className="text-ink-400 hover:text-ink-700"
+            >
               <X className="size-4" />
             </button>
           </div>

--- a/src/features/admin/AdminPage.tsx
+++ b/src/features/admin/AdminPage.tsx
@@ -88,7 +88,7 @@ function LigasAdmin() {
   if (isLoading) return <Skeleton className="h-40 w-full" />;
 
   // federações já excluídas (soft) saem das listas normais e vão pra Lixeira
-  const live = (leagues ?? []).filter((l) => !(l as { deleted_at?: string | null }).deleted_at);
+  const live = (leagues ?? []).filter((l) => !l.deleted_at);
   const pending = live.filter((l) => l.status === "pending");
   const others = live.filter((l) => l.status !== "pending");
 
@@ -266,7 +266,7 @@ function CompeticoesAdmin() {
   const dupGroups = useMemo(() => {
     const m = new Map<string, string[]>();
     for (const c of comps ?? []) {
-      const k = normalizeName((c as { display_name?: string }).display_name || c.name);
+      const k = normalizeName(c.display_name || c.name);
       if (!k) continue;
       const arr = m.get(k) ?? [];
       arr.push(c.id);

--- a/src/features/admin/api.ts
+++ b/src/features/admin/api.ts
@@ -10,7 +10,7 @@ export function usePendingLeagues() {
         .from("leagues")
         .select("*, owner:profiles!leagues_owner_id_fkey(display_name)")
         .order("created_at", { ascending: false });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return (data ?? []) as unknown as (League & { owner: { display_name: string } | null })[];
     },
   });
@@ -21,7 +21,7 @@ export function useApproveLeague() {
   return useMutation({
     mutationFn: async (id: string) => {
       const { error } = await supabase.rpc("approve_league", { p_league_id: id });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["admin", "pending-leagues"] }),
   });
@@ -32,7 +32,7 @@ export function useRejectLeague() {
   return useMutation({
     mutationFn: async (id: string) => {
       const { error } = await supabase.rpc("reject_league", { p_league_id: id });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["admin", "pending-leagues"] }),
   });
@@ -46,7 +46,7 @@ export function useAdminCompetitions() {
         .from("competitions")
         .select("*")
         .order("created_at", { ascending: false });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return data ?? [];
     },
   });
@@ -104,7 +104,7 @@ export function useSyncFootball() {
       const { data, error } = await supabase.functions.invoke("sync-football", {
         body: competitionId ? { competitionId } : {},
       });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return data as { synced: number; results: { competition: string; ok: boolean; error?: string }[] };
     },
     onSuccess: () => {
@@ -145,7 +145,7 @@ export function useAdminMatches(competitionId: string | undefined) {
         .select(ADMIN_MATCH_SELECT)
         .eq("competition_id", competitionId!)
         .order("kickoff_at");
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return (data ?? []) as unknown as AdminMatch[];
     },
   });
@@ -155,12 +155,11 @@ export function useSetMatchHidden() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (input: { matchId: string; hidden: boolean }) => {
-      // coluna nova (fora dos types gerados) → cast pontual
       const { error } = await supabase
         .from("matches")
-        .update({ hidden: input.hidden } as never)
+        .update({ hidden: input.hidden })
         .eq("id", input.matchId);
-      if (error) throw error;
+      if (error) throw new Error(error.message);
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["admin", "matches"] });
@@ -186,7 +185,7 @@ export function useSaveMatchResult() {
           status: input.status,
         })
         .eq("id", input.matchId);
-      if (error) throw error;
+      if (error) throw new Error(error.message);
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["admin", "matches"] });
@@ -217,7 +216,7 @@ export function useCreateMatch() {
         group_name: input.groupName || null,
         status: "scheduled",
       });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["admin", "matches"] }),
   });
@@ -239,7 +238,7 @@ export function useAllProfiles() {
       // E-mail não fica mais em public.profiles (PII). A RPC lê de auth.users
       // e só responde para app_admin.
       const { data, error } = await supabase.rpc("admin_list_users");
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return (data ?? []) as AdminUser[];
     },
   });
@@ -253,7 +252,7 @@ export function useSetAppAdmin() {
         p_user_id: input.userId,
         p_value: input.value,
       });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["admin", "profiles"] }),
   });

--- a/src/features/auth/AuthProvider.tsx
+++ b/src/features/auth/AuthProvider.tsx
@@ -20,7 +20,6 @@ interface AuthContextValue {
   refreshProfile: () => Promise<void>;
   signInWithGoogle: () => Promise<{ error: string | null }>;
   signInWithPassword: (email: string, password: string) => Promise<{ error: string | null }>;
-  signUp: (email: string, password: string, name: string) => Promise<{ error: string | null }>;
   signOut: () => Promise<void>;
 }
 
@@ -98,15 +97,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return { error: error?.message ?? null };
   }, []);
 
-  const signUp = useCallback(async (email: string, password: string, name: string) => {
-    const { error } = await supabase.auth.signUp({
-      email,
-      password,
-      options: { data: { full_name: name } },
-    });
-    return { error: error?.message ?? null };
-  }, []);
-
   const signOut = useCallback(async () => {
     await supabase.auth.signOut();
     setProfile(null);
@@ -122,10 +112,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       refreshProfile,
       signInWithGoogle,
       signInWithPassword,
-      signUp,
       signOut,
     }),
-    [session, profile, loading, refreshProfile, signInWithGoogle, signInWithPassword, signUp, signOut],
+    [session, profile, loading, refreshProfile, signInWithGoogle, signInWithPassword, signOut],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/features/auth/LoginModal.tsx
+++ b/src/features/auth/LoginModal.tsx
@@ -46,9 +46,20 @@ export function LoginModal({ open, onClose }: { open: boolean; onClose: () => vo
     // sucesso: o OAuth redireciona; não precisa mexer no estado aqui
   }
 
+  // Login de desenvolvimento: só aparece quando rodando em DEV e quando AMBAS as
+  // variáveis (e-mail + senha) estiverem definidas no ambiente. Sem credenciais
+  // hardcoded no código.
+  const devLogin =
+    import.meta.env.DEV &&
+    import.meta.env.VITE_DEV_LOGIN_EMAIL &&
+    import.meta.env.VITE_DEV_LOGIN_PASSWORD;
+
   async function handleDevLogin() {
     setBusy(true);
-    const { error } = await signInWithPassword("joao.crf93@gmail.com", "resultadismo123");
+    const { error } = await signInWithPassword(
+      import.meta.env.VITE_DEV_LOGIN_EMAIL,
+      import.meta.env.VITE_DEV_LOGIN_PASSWORD,
+    );
     if (error) {
       toast(error, "error");
       setBusy(false);
@@ -77,7 +88,7 @@ export function LoginModal({ open, onClose }: { open: boolean; onClose: () => vo
           </Button>
           <p className="mt-3 text-xs text-ink-400">Rapidinho, sem senha nova pra decorar.</p>
 
-          {import.meta.env.DEV && (
+          {devLogin && (
             <button
               type="button"
               onClick={handleDevLogin}

--- a/src/features/auth/LoginPage.tsx
+++ b/src/features/auth/LoginPage.tsx
@@ -47,12 +47,22 @@ export function LoginPage() {
 
   async function handleDevLogin() {
     setBusy(true);
-    const { error } = await signInWithPassword("joao.crf93@gmail.com", "resultadismo123");
+    const { error } = await signInWithPassword(
+      import.meta.env.VITE_DEV_LOGIN_EMAIL,
+      import.meta.env.VITE_DEV_LOGIN_PASSWORD,
+    );
     if (error) {
       toast(error, "error");
       setBusy(false);
     }
   }
+
+  // Login de desenvolvimento: só em DEV e somente quando AMBAS as variáveis
+  // (e-mail + senha) estiverem definidas. Sem credenciais hardcoded no código.
+  const devLogin =
+    import.meta.env.DEV &&
+    import.meta.env.VITE_DEV_LOGIN_EMAIL &&
+    import.meta.env.VITE_DEV_LOGIN_PASSWORD;
 
   return (
     <div className="grid min-h-dvh place-items-center bg-background px-5 py-10">
@@ -72,7 +82,7 @@ export function LoginPage() {
             Use sua conta Google para entrar e jogar.
           </p>
 
-          {import.meta.env.DEV && (
+          {devLogin && (
             <button
               type="button"
               onClick={handleDevLogin}

--- a/src/features/confronto/ConfrontoSection.tsx
+++ b/src/features/confronto/ConfrontoSection.tsx
@@ -20,7 +20,14 @@ import { cn } from "@/lib/utils";
 import { supabase } from "@/lib/supabase";
 import { useLeagueMembers } from "@/features/leagues/api";
 import { MAX_JOGADORES } from "./simulator";
-import { roundsNeeded, buildLigaFixtures, buildCopaFixtures, type Period, type DrawTie } from "./build";
+import {
+  roundsNeeded,
+  buildLigaFixtures,
+  buildCopaFixtures,
+  shuffleSeeded,
+  type Period,
+  type DrawTie,
+} from "./build";
 import {
   useConfrontoTies,
   useConfrontoPeriods,
@@ -29,6 +36,7 @@ import {
   useDrawConfronto,
   useUndoDraw,
   useAdvanceSwiss,
+  useAdvanceCup,
   type ConfrontoFormato,
   type ConfrontoTie,
   type PeriodKind,
@@ -210,11 +218,12 @@ function SorteioPanel({
   const { data: members } = useLeagueMembers(leagueId);
   const allPlayers = useMemo(() => {
     const active = (members ?? []).filter((m) => m.status === "active");
-    active.sort((a, b) => (a.joined_at ?? "").localeCompare(b.joined_at ?? ""));
-    return active
+    const mapped = active
       .map((m) => ({ id: m.profile?.id as string, name: m.profile?.display_name ?? "—" }))
       .filter((p) => p.id);
-  }, [members]);
+    // "sorteio" da ordem: embaralha de forma estável (seed = id da disputa).
+    return shuffleSeeded(mapped, lcId);
+  }, [members, lcId]);
   const nameOf = (id: string | null) =>
     id ? (allPlayers.find((p) => p.id === id)?.name ?? "—") : "—";
 
@@ -574,9 +583,9 @@ function SorteioPanel({
             {isLiga ? "Rodada 1" : (previewRound1[0]?.round_label ?? "1ª fase")}
           </p>
           <ul className="space-y-1">
-            {previewRound1.map((t, i) => (
+            {previewRound1.map((t) => (
               <li
-                key={i}
+                key={`${t.round_order}-${t.slot}`}
                 className="flex items-center gap-2 rounded-md bg-surface-2 px-2.5 py-1.5 text-sm"
               >
                 <span className="min-w-0 flex-1 truncate text-right font-semibold text-ink-900">
@@ -619,7 +628,7 @@ function SorteioPanel({
             </p>
           )}
           <p className="mt-2 text-[11px] leading-relaxed text-ink-400">
-            A ordem segue a entrada na federação. É exatamente o confronto que será criado.
+            A ordem dos confrontos é sorteada. É exatamente o confronto que será criado.
           </p>
         </div>
       )}
@@ -800,8 +809,18 @@ function DrawnView({
   const { data: ties, isLoading } = useConfrontoTies(lcId);
   const undo = useUndoDraw();
   const advance = useAdvanceSwiss();
+  const advanceCup = useAdvanceCup();
   const [openTie, setOpenTie] = useState<ConfrontoTie | null>(null);
   const [tab, setTab] = useState<"tabela" | "rodadas">("tabela");
+
+  // Copa: ao abrir o chaveamento (e quando os resultados mudam), promove os
+  // vencedores p/ a próxima fase. Idempotente — converge (só invalida se mexeu).
+  useEffect(() => {
+    if (formato === "cup" && (ties?.length ?? 0) > 0) {
+      advanceCup.mutate({ lcId });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formato, lcId, ties]);
 
   if (isLoading) return <Skeleton className="h-64 w-full" />;
   const list = ties ?? [];

--- a/src/features/confronto/ConfrontoViews.tsx
+++ b/src/features/confronto/ConfrontoViews.tsx
@@ -173,13 +173,13 @@ export function ConfrontoRounds({
       if (!map.has(t.round_order)) map.set(t.round_order, { label: t.round_label, ties: [] });
       map.get(t.round_order)!.ties.push(t);
     }
-    return [...map.entries()].sort((a, b) => a[0] - b[0]).map(([, v]) => v);
+    return [...map.entries()].sort((a, b) => a[0] - b[0]).map(([order, v]) => ({ order, ...v }));
   }, [ties]);
 
   return (
     <div className="space-y-3">
-      {rounds.map((r, i) => (
-        <div key={i}>
+      {rounds.map((r) => (
+        <div key={r.order}>
           <h4 className="mb-1.5 px-1 text-xs font-bold uppercase tracking-wide text-ink-400">
             {r.label}
           </h4>
@@ -425,14 +425,14 @@ export function CopaBracket({
     }
     return [...map.entries()]
       .sort((a, b) => a[0] - b[0])
-      .map(([, v]) => ({ ...v, ties: v.ties.sort((a, b) => a.slot - b.slot) }));
+      .map(([order, v]) => ({ order, ...v, ties: v.ties.sort((a, b) => a.slot - b.slot) }));
   }, [ties]);
 
   return (
     <div className="no-scrollbar overflow-x-auto pb-2">
       <div className="flex gap-3" style={{ minWidth: rounds.length * 180 }}>
-        {rounds.map((r, i) => (
-          <div key={i} className="flex min-w-[168px] flex-1 flex-col justify-around gap-3">
+        {rounds.map((r) => (
+          <div key={r.order} className="flex min-w-[168px] flex-1 flex-col justify-around gap-3">
             <h4 className="text-center text-xs font-bold uppercase tracking-wide text-ink-400">
               {r.label}
             </h4>

--- a/src/features/confronto/api.ts
+++ b/src/features/confronto/api.ts
@@ -55,7 +55,7 @@ export function useConfrontoStandings(lcId: string | undefined, enabled = true) 
     queryKey: ["confronto-standings", lcId],
     queryFn: async (): Promise<ConfrontoStanding[]> => {
       const { data, error } = await supabase.rpc("get_confronto_standings", { p_lc_id: lcId! });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return (data ?? []) as ConfrontoStanding[];
     },
   });
@@ -68,7 +68,7 @@ export function useConfrontoTies(lcId: string | undefined, enabled = true) {
     queryKey: ["confronto-ties", lcId],
     queryFn: async (): Promise<ConfrontoTie[]> => {
       const { data, error } = await supabase.rpc("get_confronto_ties", { p_lc_id: lcId! });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return (data ?? []) as ConfrontoTie[];
     },
   });
@@ -102,7 +102,7 @@ export function useTieDetail(tieId: string | undefined, enabled = true) {
     queryKey: ["tie-detail", tieId],
     queryFn: async (): Promise<TieDetailRow[]> => {
       const { data, error } = await supabase.rpc("get_tie_detail", { p_tie_id: tieId! });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return (data ?? []) as TieDetailRow[];
     },
   });
@@ -128,25 +128,8 @@ export function useConfrontoPeriods(competitionId: string | undefined, kind: Per
         p_competition_id: competitionId!,
         p_kind: kind,
       });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return (data ?? []) as ConfrontoPeriod[];
-    },
-  });
-}
-
-/** Participantes travados no sorteio. */
-export function useConfrontoParticipants(lcId: string | undefined, enabled = true) {
-  return useQuery({
-    enabled: !!lcId && enabled,
-    queryKey: ["confronto-participants", lcId],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("confronto_participants")
-        .select("user_id, seed, profile:profiles(display_name, avatar_url)")
-        .eq("league_competition_id", lcId!)
-        .order("seed");
-      if (error) throw error;
-      return data ?? [];
     },
   });
 }
@@ -161,7 +144,7 @@ export function useConfrontoOptins(lcId: string | undefined, enabled = true) {
         .from("confronto_optins")
         .select("user_id")
         .eq("league_competition_id", lcId!);
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return (data ?? []).map((r) => r.user_id as string);
     },
   });
@@ -250,7 +233,7 @@ export function useDrawConfronto() {
         p_period_kind: input.kind ?? "phase",
         p_scheduled_draw_at: input.scheduledDrawAt ?? undefined,
       });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return { ties: ties.length, participants: ids.length, scheduled: !!input.scheduledDrawAt };
     },
     onSuccess: (_r, v) => invalidateConfronto(qc, v.lcId, v.leagueId),
@@ -263,7 +246,7 @@ export function useUndoDraw() {
   return useMutation({
     mutationFn: async (input: { lcId: string; leagueId: string }) => {
       const { error } = await supabase.rpc("undo_confronto_draw", { p_lc_id: input.lcId });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
     },
     onSuccess: (_r, v) => invalidateConfronto(qc, v.lcId, v.leagueId),
   });
@@ -339,5 +322,24 @@ export function useAdvanceSwiss() {
       return { lcId: input.lcId, created: newTies.length, round: maxRound + 1 };
     },
     onSuccess: (r) => invalidateConfronto(qc, r.lcId),
+  });
+}
+
+/**
+ * Copa (mata-mata): promove o vencedor de cada chave para a próxima fase.
+ * Idempotente (só preenche slot vazio) — chamada "lazy" pelo client ao abrir o
+ * chaveamento; o avanço de fato acontece no servidor (advance_confronto_cup).
+ */
+export function useAdvanceCup() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: { lcId: string; leagueId?: string }) => {
+      const { data, error } = await supabase.rpc("advance_confronto_cup", { p_lc_id: input.lcId });
+      if (error) throw new Error(error.message);
+      return (data ?? 0) as number;
+    },
+    onSuccess: (created, v) => {
+      if (created > 0) invalidateConfronto(qc, v.lcId, v.leagueId);
+    },
   });
 }

--- a/src/features/confronto/build.ts
+++ b/src/features/confronto/build.ts
@@ -159,6 +159,33 @@ export function pairKey(a: string, b: string): string {
 }
 
 /**
+ * Embaralhamento determinístico (Fisher-Yates) com seed — o "sorteio" da ordem.
+ * Seedado pelo id da disputa: o resultado é estável (a prévia bate com o que é
+ * gravado e não muda a cada render), mas não segue a ordem de entrada — tira o
+ * viés de "quem entrou primeiro pega o seed 1".
+ */
+export function shuffleSeeded<T>(arr: T[], seed: string): T[] {
+  let h = 1779033703 ^ seed.length;
+  for (let i = 0; i < seed.length; i++) {
+    h = Math.imul(h ^ seed.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  let a = h >>> 0;
+  const rng = () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+  const out = [...arr];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [out[i], out[j]] = [out[j]!, out[i]!];
+  }
+  return out;
+}
+
+/**
  * Suíço: monta a PRÓXIMA rodada pareando por classificação (`order`, melhor
  * primeiro) e evitando revanches (`played`). Ímpar → último ganha folga (bye).
  */

--- a/src/features/leagues/LigaDetailPage.tsx
+++ b/src/features/leagues/LigaDetailPage.tsx
@@ -87,8 +87,11 @@ export function LigaDetailPage() {
   // (a webhook do Mercado Pago a ativa em segundos).
   useEffect(() => {
     if (league?.payment_status !== "pending") return;
+    let ticks = 0;
     const t = setInterval(() => {
+      ticks += 1;
       qc.invalidateQueries({ queryKey: ["league", slug] });
+      if (ticks >= 36) clearInterval(t); // para após ~3 min (evita poll indefinido)
     }, 5000);
     return () => clearInterval(t);
   }, [league?.payment_status, slug, qc]);
@@ -130,7 +133,7 @@ export function LigaDetailPage() {
     );
   }
 
-  const confrontoEnabled = (league as { confronto_enabled?: boolean }).confronto_enabled ?? false;
+  const confrontoEnabled = league.confronto_enabled ?? false;
 
   function copyCode() {
     if (!league?.join_code) return;
@@ -158,8 +161,7 @@ export function LigaDetailPage() {
         </Button>
       }
     >
-      {league.status === "active" &&
-        (league as { name_approved?: boolean }).name_approved === false && (
+      {league.status === "active" && league.name_approved === false && (
           <div className="mb-4 flex items-start gap-2 rounded-md bg-brand-50 p-3 text-sm text-brand-800">
             <Clock className="mt-0.5 size-4 shrink-0" />
             <p>
@@ -372,7 +374,7 @@ export function LigaDetailPage() {
         <CompeticoesTab
           leagueId={league.id}
           comps={comps ?? []}
-          confrontoEnabled={(league as { confronto_enabled?: boolean }).confronto_enabled ?? false}
+          confrontoEnabled={confrontoEnabled}
         />
       )}
 
@@ -391,7 +393,7 @@ export function LigaDetailPage() {
         <RefundFederationButton
           leagueId={league.id}
           paymentStatus={league.payment_status}
-          approvedAt={(league as { approved_at?: string | null }).approved_at}
+          approvedAt={league.approved_at}
         />
       )}
 
@@ -751,6 +753,7 @@ function CompeticoesTab({
       ) : open ? (
         <Card className="space-y-3 p-4">
           <select
+            aria-label="Competição"
             value={competitionId}
             onChange={(e) => setCompetitionId(e.target.value)}
             className="h-11 w-full rounded-md border border-ink-200 bg-surface px-3 outline-none focus:border-brand-500"

--- a/src/features/leagues/NovaLigaPage.tsx
+++ b/src/features/leagues/NovaLigaPage.tsx
@@ -239,13 +239,14 @@ export function NovaLigaPage() {
           <div className="flex flex-col gap-1.5">
             <label className="text-sm font-medium text-ink-800">Competição (bolão inicial)</label>
             <select
+              aria-label="Competição (bolão inicial)"
               value={competitionId}
               onChange={(e) => setCompetitionId(e.target.value)}
               className="h-11 rounded-md border border-ink-200 bg-surface px-3 text-ink-950 outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20"
             >
               {competitions?.map((c) => (
                 <option key={c.id} value={c.id}>
-                  {(c as { display_name?: string | null }).display_name ?? c.name}
+                  {c.display_name ?? c.name}
                 </option>
               ))}
             </select>

--- a/src/features/leagues/api.ts
+++ b/src/features/leagues/api.ts
@@ -23,7 +23,7 @@ export function useMyLeagues() {
         .from("league_members")
         .select("role, status, league:leagues(*)")
         .eq("user_id", user!.id);
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return (data ?? [])
         .filter((r) => r.league && !(r.league as { deleted_at?: string | null }).deleted_at)
         .map((r) => ({
@@ -45,9 +45,9 @@ export function useLeague(slug: string | undefined) {
         .select("*")
         .eq("slug", slug!)
         .maybeSingle();
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       // federação excluída (soft) não abre pra ninguém (admin restaura pela Lixeira)
-      if ((data as { deleted_at?: string | null } | null)?.deleted_at) return null;
+      if (data?.deleted_at) return null;
       return data;
     },
   });
@@ -71,7 +71,7 @@ export function useLeagueMembers(leagueId: string | undefined) {
         .select("id, role, status, joined_at, profile:profiles(id, display_name, avatar_url)")
         .eq("league_id", leagueId!)
         .order("joined_at");
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return (data ?? []) as unknown as MemberWithProfile[];
     },
   });
@@ -87,7 +87,7 @@ export function useLeagueCompetitions(leagueId: string | undefined) {
         .select("*, competition:competitions(name, emblem_url)")
         .eq("league_id", leagueId!)
         .order("created_at");
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return (data ?? []) as unknown as (LeagueCompetition & {
         competition: { name: string; emblem_url: string | null } | null;
       })[];
@@ -101,7 +101,7 @@ export function useStandings(lcId: string | undefined) {
     queryKey: ["standings", lcId],
     queryFn: async (): Promise<StandingRow[]> => {
       const { data, error } = await supabase.rpc("get_league_standings", { p_lc_id: lcId! });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return data ?? [];
     },
   });
@@ -156,7 +156,7 @@ export function useCreateLeague() {
         })
         .select()
         .single();
-      if (error) throw error;
+      if (error) throw new Error(error.message);
 
       if (input.competitionId) {
         const { error: lcErr } = await supabase.from("league_competitions").insert({
@@ -198,7 +198,7 @@ export function useJoinByCode() {
   return useMutation({
     mutationFn: async (code: string) => {
       const { data, error } = await supabase.rpc("join_league_by_code", { p_code: code });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return data;
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["my-leagues"] }),
@@ -230,7 +230,7 @@ export function useAddLeagueCompetition() {
         })
         .select()
         .single();
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return data;
     },
     onSuccess: (_d, v) =>
@@ -248,7 +248,7 @@ export function useUpdateLeagueLogo() {
         .from("leagues")
         .update({ logo_url: input.logoUrl })
         .eq("id", input.leagueId);
-      if (error) throw error;
+      if (error) throw new Error(error.message);
     },
     onSuccess: (_d, v) => {
       qc.invalidateQueries({ queryKey: ["league"] });
@@ -268,7 +268,7 @@ export function useDeleteLeagueCompetition() {
         .from("league_competitions")
         .delete()
         .eq("id", input.lcId);
-      if (error) throw error;
+      if (error) throw new Error(error.message);
     },
     onSuccess: (_d, v) => {
       qc.invalidateQueries({ queryKey: ["league-competitions", v.leagueId] });
@@ -292,7 +292,7 @@ export function useUpdateMember() {
         .from("league_members")
         .update(patch)
         .eq("id", input.memberId);
-      if (error) throw error;
+      if (error) throw new Error(error.message);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["league-members"] }),
   });
@@ -303,7 +303,7 @@ export function useRemoveMember() {
   return useMutation({
     mutationFn: async (memberId: string) => {
       const { error } = await supabase.from("league_members").delete().eq("id", memberId);
-      if (error) throw error;
+      if (error) throw new Error(error.message);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["league-members"] }),
   });

--- a/src/features/matches/JogosPage.tsx
+++ b/src/features/matches/JogosPage.tsx
@@ -106,7 +106,7 @@ export function JogosPage() {
     if (!matches || !predMap) return m;
     for (const mt of matches) {
       if (!predMap.get(mt.id)?.is_joker) continue;
-      const compKey = (mt as { competition_id?: string }).competition_id ?? "?";
+      const compKey = mt.competition_id ?? "?";
       const k = `${compKey}:${weekKey(mt.kickoff_at)}`;
       m.set(k, (m.get(k) ?? 0) + 1);
     }
@@ -274,7 +274,7 @@ export function JogosPage() {
       ) : (
         <div className="space-y-3">
           {dayMatches.map((m) => {
-            const compKey = (m as { competition_id?: string }).competition_id ?? "?";
+            const compKey = m.competition_id ?? "?";
             const wk = weekKey(m.kickoff_at);
             return (
               <MatchCard

--- a/src/features/matches/api.ts
+++ b/src/features/matches/api.ts
@@ -19,7 +19,7 @@ export function findWorldCupCompetition(
   if (!comps?.length) return undefined;
   return comps.find((c) => {
     const code = (c.provider_code ?? "").toUpperCase();
-    const name = `${(c as { display_name?: string | null }).display_name ?? ""} ${c.name}`.toLowerCase();
+    const name = `${c.display_name ?? ""} ${c.name}`.toLowerCase();
     return (
       code === "WC" ||
       code === "4429" || // TheSportsDB FIFA World Cup
@@ -37,15 +37,13 @@ export function useCompetitions() {
     staleTime: 5 * 60_000,
     placeholderData: keepPreviousData,
     queryFn: async (): Promise<Competition[]> => {
-      // colunas `is_published` e `display_name` foram adicionadas via migração
-      // depois dos types gerados — cast para `any` evita ter que rerodar `supabase gen types`.
       let q = supabase.from("competitions").select("*").eq("status", "active");
       // público só vê publicadas; admin enxerga tudo (incl. rascunhos)
-      if (!isAppAdmin) q = (q as unknown as { eq: (c: string, v: unknown) => typeof q }).eq("is_published", true);
+      if (!isAppAdmin) q = q.eq("is_published", true);
       const { data, error } = await q
         .order("is_featured", { ascending: false })
         .order("name");
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return data ?? [];
     },
   });
@@ -65,23 +63,21 @@ export function useMatches(competitionId: string | undefined) {
         .select("created_at")
         .eq("id", competitionId!)
         .maybeSingle();
-      if (compErr) throw compErr;
+      if (compErr) throw new Error(compErr.message);
       const since = comp?.created_at ?? null;
 
+      // jogos ocultados pelo admin saem no servidor (usa o índice parcial
+      // matches_visible_idx) — não viajam pela rede nem aparecem para palpitar.
       let q = supabase
         .from("matches")
         .select(MATCH_SELECT)
         .eq("competition_id", competitionId!)
+        .eq("hidden", false)
         .order("kickoff_at", { ascending: true });
       if (since) q = q.gte("kickoff_at", since);
       const { data, error } = await q;
-      if (error) throw error;
-      // jogos ocultados pelo admin não entram para palpitar. Filtro client-side
-      // (resiliente: se a coluna `hidden` ainda não existir no deploy, m.hidden
-      // é undefined e nada é escondido — sem quebrar a tela).
-      return (data ?? []).filter(
-        (m) => !(m as { hidden?: boolean }).hidden,
-      ) as unknown as MatchWithTeams[];
+      if (error) throw new Error(error.message);
+      return (data ?? []) as unknown as MatchWithTeams[];
     },
   });
 }
@@ -100,26 +96,26 @@ export function useAllMatches(enabled = true) {
     placeholderData: keepPreviousData,
     queryFn: async (): Promise<MatchWithTeams[]> => {
       let cq = supabase.from("competitions").select("id, created_at").eq("status", "active");
-      if (!isAppAdmin)
-        cq = (cq as unknown as { eq: (c: string, v: unknown) => typeof cq }).eq("is_published", true);
+      if (!isAppAdmin) cq = cq.eq("is_published", true);
       const { data: comps, error: ce } = await cq;
-      if (ce) throw ce;
-      const ids = (comps ?? []).map((c) => (c as { id: string }).id);
+      if (ce) throw new Error(ce.message);
+      const ids = (comps ?? []).map((c) => c.id);
       if (ids.length === 0) return [];
       const createdMap = new Map<string, string | null>(
-        (comps ?? []).map((c) => [(c as { id: string }).id, (c as { created_at?: string }).created_at ?? null]),
+        (comps ?? []).map((c) => [c.id, c.created_at ?? null]),
       );
       const floor = new Date(Date.now() - 7 * 86_400_000).toISOString();
       const { data, error } = await supabase
         .from("matches")
         .select(MATCH_SELECT)
         .in("competition_id", ids)
+        .eq("hidden", false)
         .gte("kickoff_at", floor)
         .order("kickoff_at", { ascending: true });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
+      // só resta o piso por-competição (created_at), que é por linha → fica em JS.
       return (data ?? []).filter((m) => {
-        const row = m as { hidden?: boolean; competition_id: string; kickoff_at: string | null };
-        if (row.hidden) return false;
+        const row = m as unknown as { competition_id: string; kickoff_at: string | null };
         const created = createdMap.get(row.competition_id);
         return !created || !row.kickoff_at || row.kickoff_at >= created;
       }) as unknown as MatchWithTeams[];
@@ -141,7 +137,7 @@ export function useMyPredictions(competitionId: string | undefined) {
         .select("*, matches!inner(competition_id)")
         .eq("user_id", user!.id)
         .eq("matches.competition_id", competitionId!);
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       const map = new Map<string, Prediction>();
       for (const row of data ?? []) {
         const { matches: _m, ...pred } = row as Prediction & { matches: unknown };
@@ -165,7 +161,7 @@ export function useAllMyPredictions(enabled = true) {
         .from("predictions")
         .select("*")
         .eq("user_id", user!.id);
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       const map = new Map<string, Prediction>();
       for (const row of data ?? []) map.set((row as Prediction).match_id, row as Prediction);
       return map;
@@ -191,7 +187,7 @@ export function useSavePrediction() {
         )
         .select()
         .single();
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return data;
     },
     onSuccess: () => {
@@ -210,7 +206,7 @@ export function useSetJoker() {
         .update({ is_joker: input.value })
         .eq("user_id", user!.id)
         .eq("match_id", input.matchId);
-      if (error) throw error;
+      if (error) throw new Error(error.message);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["my-predictions"] }),
   });
@@ -237,7 +233,7 @@ export function useMatchPredictions(matchId: string, enabled: boolean) {
         )
         .eq("match_id", matchId)
         .order("points", { ascending: false, nullsFirst: false });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return (data ?? []) as unknown as MatchPrediction[];
     },
   });
@@ -260,7 +256,7 @@ export function useMatchPredictStatus(matchId: string, enabled: boolean) {
       const { data, error } = await supabase.rpc("get_match_predict_status", {
         p_match_id: matchId,
       });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return (data ?? []) as MatchPredictStatus[];
     },
   });

--- a/src/features/notifications/NotificationsBell.tsx
+++ b/src/features/notifications/NotificationsBell.tsx
@@ -38,7 +38,13 @@ export function NotificationsBell({ className }: { className?: string }) {
 
       {open && (
         <>
-          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <button
+            type="button"
+            aria-label="Fechar"
+            tabIndex={-1}
+            onClick={() => setOpen(false)}
+            className="fixed inset-0 z-40 cursor-default"
+          />
           <div className="animate-pop-in absolute right-0 top-11 z-50 w-80 max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg bg-surface shadow-[var(--shadow-pop)] ring-1 ring-border">
             <div className="border-b border-border px-4 py-2.5 text-sm font-bold text-ink-900">
               Notificações

--- a/src/features/payments/api.ts
+++ b/src/features/payments/api.ts
@@ -1,20 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/lib/supabase";
 
-// As tabelas/RPCs novas (app_settings, discount_codes, *_league_payment) ainda não
-// estão nos tipos gerados. Mantemos os casts contidos aqui (e tipamos os resultados),
-// evitando mexer no database.ts (menos superfície de conflito com outras sessões).
-type LooseClient = {
-  from: (t: string) => {
-    select: (c?: string) => any;
-    insert: (v: unknown) => any;
-    update: (v: unknown) => any;
-    delete: () => any;
-  };
-  rpc: (fn: string, args?: Record<string, unknown>) => Promise<{ data: unknown; error: unknown }>;
-};
-const db = supabase as unknown as LooseClient;
-
 export type PaymentMode = "disabled" | "test" | "live";
 
 export type PaymentSettings = {
@@ -70,12 +56,11 @@ export function usePaymentSettings() {
     queryKey: ["payment-settings"],
     staleTime: 30_000,
     queryFn: async (): Promise<PaymentSettings> => {
-      const { data, error } = await db
-        .from("app_settings")
+      const { data, error } = await supabase.from("app_settings")
         .select("payment_mode, league_price_cents, promo_price_cents, promo_until")
         .eq("id", 1)
         .maybeSingle();
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return (data as PaymentSettings | null) ?? DEFAULT_SETTINGS;
     },
   });
@@ -91,17 +76,18 @@ export function useUpdatePaymentSettings() {
       promoUntil: string | null;
     }) => {
       // 1) modo + preço base
-      const { error } = await db.rpc("admin_update_payment_settings", {
+      const { error } = await supabase.rpc("admin_update_payment_settings", {
         p_mode: input.mode,
         p_price_cents: input.priceCents,
       });
-      if (error) throw error;
-      // 2) promoção (preço + validade); promo_price_cents null limpa a promo
-      const { error: promoErr } = await db.rpc("admin_set_promo", {
-        p_promo_price_cents: input.promoPriceCents,
-        p_promo_until: input.promoUntil,
+      if (error) throw new Error(error.message);
+      // 2) promoção (preço + validade). null → undefined: o param tem default null
+      // no SQL, então omitir tem o mesmo efeito (limpa a promo).
+      const { error: promoErr } = await supabase.rpc("admin_set_promo", {
+        p_promo_price_cents: input.promoPriceCents ?? undefined,
+        p_promo_until: input.promoUntil ?? undefined,
       });
-      if (promoErr) throw promoErr;
+      if (promoErr) throw new Error(promoErr.message);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["payment-settings"] }),
   });
@@ -117,8 +103,8 @@ export function applyDiscount(cents: number, info?: DiscountInfo | null): number
 }
 
 export async function validateDiscount(code: string): Promise<DiscountInfo> {
-  const { data, error } = await db.rpc("validate_discount_code", { p_code: code });
-  if (error) throw error;
+  const { data, error } = await supabase.rpc("validate_discount_code", { p_code: code });
+  if (error) throw new Error(error.message);
   return (data as DiscountInfo) ?? { valid: false, reason: "Código inválido." };
 }
 
@@ -127,11 +113,11 @@ export function useSimulatePayment() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (input: { leagueId: string; code?: string }) => {
-      const { error } = await db.rpc("simulate_league_payment", {
+      const { error } = await supabase.rpc("simulate_league_payment", {
         p_league_id: input.leagueId,
-        p_discount_code: input.code ?? null,
+        p_discount_code: input.code ?? undefined,
       });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["league"] });
@@ -145,8 +131,8 @@ export function useCompLeague() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (leagueId: string) => {
-      const { error } = await db.rpc("admin_comp_league", { p_league_id: leagueId });
-      if (error) throw error;
+      const { error } = await supabase.rpc("admin_comp_league", { p_league_id: leagueId });
+      if (error) throw new Error(error.message);
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["league"] });
@@ -186,8 +172,8 @@ export function useApproveName() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (leagueId: string) => {
-      const { error } = await db.rpc("admin_approve_league_name", { p_league_id: leagueId });
-      if (error) throw error;
+      const { error } = await supabase.rpc("admin_approve_league_name", { p_league_id: leagueId });
+      if (error) throw new Error(error.message);
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["league"] });
@@ -201,13 +187,12 @@ export function useNameReviewLeagues(enabled = true) {
     enabled,
     queryKey: ["name-review"],
     queryFn: async (): Promise<{ id: string; name: string; slug: string }[]> => {
-      const { data, error } = await db
-        .from("leagues")
+      const { data, error } = await supabase.from("leagues")
         .select("id, name, slug")
         .eq("name_approved", false)
         .is("deleted_at", null)
         .order("created_at", { ascending: false });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return (data as { id: string; name: string; slug: string }[]) ?? [];
     },
   });
@@ -221,11 +206,10 @@ export function useDiscountCodes(enabled = true) {
     enabled,
     queryKey: ["discount-codes"],
     queryFn: async (): Promise<DiscountCode[]> => {
-      const { data, error } = await db
-        .from("discount_codes")
+      const { data, error } = await supabase.from("discount_codes")
         .select("*")
         .order("created_at", { ascending: false });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
       return (data as DiscountCode[]) ?? [];
     },
   });
@@ -241,14 +225,14 @@ export function useCreateDiscount() {
       maxUses?: number | null;
       expiresAt?: string | null;
     }) => {
-      const { error } = await db.from("discount_codes").insert({
+      const { error } = await supabase.from("discount_codes").insert({
         code: input.code.trim().toUpperCase(),
         percent_off: input.percentOff ?? null,
         amount_off_cents: input.amountOffCents ?? null,
         max_uses: input.maxUses ?? null,
         expires_at: input.expiresAt ?? null,
       });
-      if (error) throw error;
+      if (error) throw new Error(error.message);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["discount-codes"] }),
   });
@@ -258,11 +242,10 @@ export function useToggleDiscount() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (input: { id: string; active: boolean }) => {
-      const { error } = await db
-        .from("discount_codes")
+      const { error } = await supabase.from("discount_codes")
         .update({ active: input.active })
         .eq("id", input.id);
-      if (error) throw error;
+      if (error) throw new Error(error.message);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["discount-codes"] }),
   });
@@ -272,8 +255,8 @@ export function useDeleteDiscount() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (id: string) => {
-      const { error } = await db.from("discount_codes").delete().eq("id", id);
-      if (error) throw error;
+      const { error } = await supabase.from("discount_codes").delete().eq("id", id);
+      if (error) throw new Error(error.message);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["discount-codes"] }),
   });

--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -11,18 +11,6 @@ export type AvatarShape =
   | "hexagon"
   | "diamond";
 
-export const AVATAR_SHAPES: { key: AvatarShape; label: string }[] = [
-  // escudos de clube primeiro
-  { key: "shield", label: "Escudo" },
-  { key: "ogival", label: "Ogival" },
-  { key: "banner", label: "Bandeira" },
-  // formas geométricas
-  { key: "circle", label: "Círculo" },
-  { key: "squircle", label: "Quadrado" },
-  { key: "hexagon", label: "Hexágono" },
-  { key: "diamond", label: "Losango" },
-];
-
 export const AVATAR_COLORS: { key: string; hex: string; dark?: boolean }[] = [
   { key: "turquesa", hex: "#1CB19C" },
   { key: "verde", hex: "#43921E" },
@@ -35,8 +23,6 @@ export const AVATAR_COLORS: { key: string; hex: string; dark?: boolean }[] = [
   // opção clara (branco gelo, levemente tintado de turquesa) — texto escuro
   { key: "gelo", hex: "#EAF0F0", dark: true },
 ];
-
-export const AVATAR_ROTATIONS = [0, 45, 90, 135];
 
 // polígonos em % (escalam em qualquer tamanho). Crests com vértices suficientes
 // para um silhueta de escudo de futebol limpa.
@@ -65,11 +51,7 @@ export function shapeStyle(shape: AvatarShape): CSSProperties {
   }
 }
 
-export type AvatarConfig = { shape: AvatarShape; colors: string[]; rotation: number };
-
-export function buildGenAvatar(shape: AvatarShape, colors: string[], rotation: number): string {
-  return `gen:${shape}:${colors.join("-")}:${rotation}`;
-}
+type AvatarConfig = { shape: AvatarShape; colors: string[]; rotation: number };
 
 export function parseGenAvatar(src: string | null | undefined): AvatarConfig | null {
   if (!src || !src.startsWith("gen:")) return null;

--- a/src/lib/crest.ts
+++ b/src/lib/crest.ts
@@ -14,6 +14,7 @@ import { AVATAR_COLORS, parseGenAvatar } from "./avatar";
 
 export type CrestKind = "escudo" | "flamula";
 export type CrestFill = "solid" | "stripes" | "grid" | "ball" | "photo";
+const CREST_FILLS: readonly CrestFill[] = ["solid", "stripes", "grid", "ball", "photo"];
 
 // ---------------------------------------------------------------------------
 // Catálogo de formas — montado AUTOMATICAMENTE a partir das pastas:
@@ -120,12 +121,16 @@ export function parseCrest(src: string | null | undefined): CrestConfig | null {
   const parts = src!.split(":");
   const kind: CrestKind = parts[1] === "flamula" ? "flamula" : "escudo";
   const shape = parts[2] || (kind === "flamula" ? DEFAULT_FLAMULA_SHAPE : DEFAULT_ESCUDO_SHAPE);
-  const fill = (parts[3] as CrestFill) || "solid";
+  const fill: CrestFill = CREST_FILLS.includes(parts[3] as CrestFill)
+    ? (parts[3] as CrestFill)
+    : "solid";
   const colors = (parts[4] || "").split("-").filter(Boolean);
   const rotation = Number.parseInt(parts[5] ?? "0", 10) || 0;
   // foto vem encodada e sem ":", mas faço join por segurança.
   const photoEnc = parts.slice(6).join(":");
-  const photo = photoEnc ? safeDecode(photoEnc) : undefined;
+  // sanitiza: avatar_url/logo_url são texto livre escrito pelo usuário; sem isso,
+  // uma foto forjada quebra o url("...") do CSS e injeta background (CSS injection).
+  const photo = photoEnc ? sanitizePhotoUrl(safeDecode(photoEnc)) : undefined;
   return {
     kind,
     shape,
@@ -142,6 +147,25 @@ function safeDecode(s: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Sanitiza a URL da foto antes de virar CSS `url(...)`. Rejeita qualquer coisa que
+ * quebre o `url("...")` ou injete outra declaração (aspas, parênteses, espaço, `;`,
+ * `<`, `>`, barra invertida) e só aceita http(s) absoluto. Caso contrário → undefined
+ * (o render cai no fundo sólido). Defesa contra CSS injection armazenada.
+ */
+function sanitizePhotoUrl(raw: string | null | undefined): string | undefined {
+  if (!raw) return undefined;
+  const s = raw.trim();
+  if (!s || /[\s"'()\\;<>]/.test(s)) return undefined;
+  try {
+    const u = new URL(s);
+    if (u.protocol === "https:" || u.protocol === "http:") return u.href;
+  } catch {
+    // não é URL absoluta válida
+  }
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -215,11 +239,12 @@ export function crestBackground(cfg: CrestConfig): string {
   const c = cfg.colors.map(hexOf);
   const rot = cfg.rotation;
   switch (cfg.fill) {
-    case "photo":
-      // sem foto: cai num sólido (a letra entra por cima no Avatar)
-      return cfg.photo
-        ? `center / cover no-repeat url("${cfg.photo}")`
-        : c[0] ?? hexOf("turquesa");
+    case "photo": {
+      // sanitiza no sink (cobre qualquer caller, não só o que passou por parseCrest);
+      // sem foto válida cai num sólido (a letra entra por cima no Avatar)
+      const safe = sanitizePhotoUrl(cfg.photo);
+      return safe ? `center / cover no-repeat url("${safe}")` : c[0] ?? hexOf("turquesa");
+    }
     case "stripes":
       if (c.length <= 1) return c[0] ?? hexOf("turquesa");
       if (c.length === 2)
@@ -255,20 +280,4 @@ export function crestTextColor(cfg: CrestConfig): string {
     return isDark(cfg.colors[0] ?? "") ? "#232323" : "#ffffff";
   }
   return "#ffffff";
-}
-
-/** quantas cores cada padrão usa (p/ os editores). */
-export function colorsForFill(fill: CrestFill): number {
-  switch (fill) {
-    case "solid":
-      return 1;
-    case "ball":
-      return 2;
-    case "grid":
-      return 4;
-    case "stripes":
-      return 2; // editor permite alternar 2 ou 3
-    default:
-      return 1;
-  }
 }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -33,11 +33,6 @@ export function formatDayLabel(iso: string | null): string {
   return d.format("dddd, DD [de] MMMM");
 }
 
-export function formatShortDate(iso: string | null): string {
-  if (!iso) return "—";
-  return dayjs(iso).format("DD/MM");
-}
-
 export function formatTime(iso: string | null): string {
   if (!iso) return "--:--";
   return dayjs(iso).format("HH:mm");

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -3,11 +3,6 @@
 // Mantenha VITE_LEAGUE_PRICE_CENTS igual ao LEAGUE_PRICE_CENTS da function.
 export const LEAGUE_PRICE_CENTS = Number(import.meta.env.VITE_LEAGUE_PRICE_CENTS ?? 990);
 
-export const LEAGUE_PRICE_BRL = (LEAGUE_PRICE_CENTS / 100).toLocaleString("pt-BR", {
-  style: "currency",
-  currency: "BRL",
-});
-
 /** Formata centavos de BRL para exibição (ex.: 990 -> "R$ 9,90"). */
 export function formatBRL(cents: number): string {
   return (cents / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -33,16 +33,6 @@ export type MatchWithTeams = Match & {
   competition?: Pick<Competition, "id" | "name" | "slug" | "emblem_url"> | null;
 };
 
-export type MatchWithPrediction = MatchWithTeams & {
-  prediction: Prediction | null;
-};
-
-export type LeagueWithMembership = League & {
-  member_count?: number;
-  my_role?: MemberRole | null;
-  my_status?: MemberStatus | null;
-};
-
 export const SCORE_POINTS: Record<ScoreType, number> = {
   cravada: 3,
   saldo: 2,

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -962,6 +962,24 @@ export type Database = {
           },
         ]
       }
+      rate_limits: {
+        Row: {
+          bucket: string
+          count: number
+          window_start: string
+        }
+        Insert: {
+          bucket: string
+          count?: number
+          window_start?: string
+        }
+        Update: {
+          bucket?: string
+          count?: number
+          window_start?: string
+        }
+        Relationships: []
+      }
       teams: {
         Row: {
           country: string | null
@@ -1133,6 +1151,7 @@ export type Database = {
           isSetofReturn: false
         }
       }
+      advance_confronto_cup: { Args: { p_lc_id: string }; Returns: number }
       append_confronto_ties: {
         Args: { p_lc_id: string; p_ties: Json }
         Returns: number
@@ -1351,6 +1370,11 @@ export type Database = {
         Args: { p_match_id: string; p_to_user: string }
         Returns: undefined
       }
+      rate_limit_hit: {
+        Args: { p_bucket: string; p_max: number; p_window_seconds: number }
+        Returns: boolean
+      }
+      refund_league: { Args: { p_league_id: string }; Returns: boolean }
       reject_league: {
         Args: { p_league_id: string }
         Returns: {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,6 +6,9 @@ interface ImportMetaEnv {
   readonly VITE_SUPABASE_ANON_KEY: string;
   readonly VITE_APP_NAME?: string;
   readonly VITE_VAPID_PUBLIC_KEY?: string;
+  // Dev-only: login rápido por senha (apenas em import.meta.env.DEV).
+  readonly VITE_DEV_LOGIN_EMAIL: string;
+  readonly VITE_DEV_LOGIN_PASSWORD: string;
 }
 
 interface ImportMeta {

--- a/supabase/functions/_shared/security.ts
+++ b/supabase/functions/_shared/security.ts
@@ -1,0 +1,45 @@
+// Helpers compartilhados pelas Edge Functions: CORS com allow-list e comparação
+// de tempo constante. (Pasta _shared/ não é deployada como função — só bundlada.)
+
+const APP_ORIGINS = (Deno.env.get("APP_URL") ?? "https://resultadismo.com")
+  .split(",")
+  .map((s) => s.trim().replace(/\/+$/, ""))
+  .filter(Boolean);
+
+function originAllowed(origin: string): boolean {
+  if (!origin) return false;
+  const o = origin.replace(/\/+$/, "");
+  if (APP_ORIGINS.includes(o)) return true;
+  // dev local
+  if (/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(o)) return true;
+  // previews da Vercel
+  if (/^https:\/\/[a-z0-9-]+\.vercel\.app$/.test(o)) return true;
+  return false;
+}
+
+/**
+ * Cabeçalhos CORS restritos: reflete a Origin só se estiver na allow-list
+ * (APP_URL, localhost, *.vercel.app). Caso contrário cai na origem principal.
+ * Substitui o antigo "Access-Control-Allow-Origin: *".
+ */
+export function corsHeaders(req: Request): Record<string, string> {
+  const origin = req.headers.get("Origin") ?? "";
+  const allow = originAllowed(origin) ? origin : APP_ORIGINS[0] ?? "";
+  return {
+    "Access-Control-Allow-Origin": allow,
+    "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Vary": "Origin",
+  };
+}
+
+/** Comparação de tempo constante p/ checagem de tokens (evita timing attacks). */
+export function timingSafeEqual(a: string, b: string): boolean {
+  const enc = new TextEncoder();
+  const ba = enc.encode(a);
+  const bb = enc.encode(b);
+  if (ba.length !== bb.length) return false;
+  let diff = 0;
+  for (let i = 0; i < ba.length; i++) diff |= (ba[i] ?? 0) ^ (bb[i] ?? 0);
+  return diff === 0;
+}

--- a/supabase/functions/cancel-league-refund/index.ts
+++ b/supabase/functions/cancel-league-refund/index.ts
@@ -12,25 +12,19 @@
 // (evita o swallow de mensagem do supabase-js functions.invoke em status != 2xx).
 
 import { createClient } from "npm:@supabase/supabase-js@2";
-
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-};
-
-function json(body: unknown, status = 200) {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { ...corsHeaders, "Content-Type": "application/json" },
-  });
-}
+import { corsHeaders } from "../_shared/security.ts";
 
 const REFUND_WINDOW_DAYS = 7;
 const DAY_MS = 86_400_000;
 
 Deno.serve(async (req) => {
-  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+  const cors = corsHeaders(req);
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { ...cors, "Content-Type": "application/json" },
+    });
+  if (req.method === "OPTIONS") return new Response("ok", { headers: cors });
 
   const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
   const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -70,7 +64,23 @@ Deno.serve(async (req) => {
   if (league.payment_status !== "paid")
     return json({ ok: false, error: "Só federações pagas podem ser reembolsadas." });
 
-  const paidAt = league.approved_at ? new Date(league.approved_at).getTime() : 0;
+  // Pagamento PAGO registrado (pega o payment_id real do Mercado Pago)
+  const { data: pay } = await admin
+    .from("league_payments")
+    .select("payment_id, provider, amount_cents, created_at")
+    .eq("league_id", league.id)
+    .eq("status", "paid")
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  // Janela de arrependimento contada a partir do PAGAMENTO (não do approved_at,
+  // que pode ter sido setado na aprovação do admin, antes do pagamento real).
+  const paidAt = pay?.created_at
+    ? new Date(pay.created_at).getTime()
+    : league.approved_at
+      ? new Date(league.approved_at).getTime()
+      : 0;
   const daysSince = paidAt ? (Date.now() - paidAt) / DAY_MS : Number.POSITIVE_INFINITY;
   if (daysSince > REFUND_WINDOW_DAYS) {
     return json({
@@ -78,16 +88,6 @@ Deno.serve(async (req) => {
       error: "O prazo de 7 dias para reembolso automático já passou. Fale com o suporte para avaliar.",
     });
   }
-
-  // Pagamento PAGO registrado (pega o payment_id real do Mercado Pago)
-  const { data: pay } = await admin
-    .from("league_payments")
-    .select("payment_id, provider, amount_cents")
-    .eq("league_id", league.id)
-    .eq("status", "paid")
-    .order("created_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
 
   const paymentId = pay?.payment_id ?? null;
   const isRealMpPayment =
@@ -122,23 +122,15 @@ Deno.serve(async (req) => {
   }
   // Cortesia / 100% off / teste: nada a estornar — apenas cancela a federação.
 
-  // 2) Marca pagamento(s) como reembolsado(s) + arquiva a federação.
+  // 2) Marca reembolsado + arquiva a federação — atômico (for update), idempotente.
   //    service_role ⇒ can_settle_leagues() = true ⇒ o guard libera status/payment_status.
-  await admin
-    .from("league_payments")
-    .update({ status: "refunded" })
-    .eq("league_id", league.id)
-    .eq("status", "paid");
-
-  const { error: upErr } = await admin
-    .from("leagues")
-    .update({
-      payment_status: "refunded",
-      status: "archived",
-      deleted_at: new Date().toISOString(),
-    })
-    .eq("id", league.id);
+  const { data: didRefund, error: upErr } = await admin.rpc("refund_league", {
+    p_league_id: league.id,
+  });
   if (upErr) return json({ ok: false, error: upErr.message });
+  if (didRefund === false) {
+    return json({ ok: false, error: "Esta federação já foi cancelada/reembolsada." });
+  }
 
   return json({ ok: true, leagueId: league.id, refunded: isRealMpPayment });
 });

--- a/supabase/functions/create-league-checkout/index.ts
+++ b/supabase/functions/create-league-checkout/index.ts
@@ -9,22 +9,16 @@
 // Secrets: MERCADOPAGO_ACCESS_TOKEN, APP_URL
 
 import { createClient } from "npm:@supabase/supabase-js@2";
-
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-};
-
-function json(body: unknown, status = 200) {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { ...corsHeaders, "Content-Type": "application/json" },
-  });
-}
+import { corsHeaders } from "../_shared/security.ts";
 
 Deno.serve(async (req) => {
-  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+  const cors = corsHeaders(req);
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { ...cors, "Content-Type": "application/json" },
+    });
+  if (req.method === "OPTIONS") return new Response("ok", { headers: cors });
 
   const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
   const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -39,6 +33,14 @@ Deno.serve(async (req) => {
   const { data: userData } = await admin.auth.getUser(jwt);
   const user = userData.user;
   if (!user) return json({ error: "Não autorizado" }, 401);
+
+  // Rate limit por usuário (evita spam de criação de preferência no MP).
+  const { data: rlOk } = await admin.rpc("rate_limit_hit", {
+    p_bucket: `checkout:${user.id}`,
+    p_max: 20,
+    p_window_seconds: 60,
+  });
+  if (rlOk === false) return json({ error: "Muitas tentativas. Tente novamente em instantes." }, 429);
 
   let body: { leagueId?: string; discountCode?: string } = {};
   try {
@@ -154,7 +156,10 @@ Deno.serve(async (req) => {
     headers: { Authorization: `Bearer ${mpToken}`, "Content-Type": "application/json" },
     body: JSON.stringify(preference),
   });
-  if (!res.ok) return json({ error: `Mercado Pago ${res.status}: ${await res.text()}` }, 502);
+  if (!res.ok) {
+    console.error("Mercado Pago preference error", res.status, await res.text());
+    return json({ error: `Pagamento indisponível no momento (${res.status}).` }, 502);
+  }
   const pref = await res.json();
   const url = pref.init_point ?? pref.sandbox_init_point;
   if (!url) return json({ error: "Mercado Pago não retornou a URL de pagamento." }, 502);

--- a/supabase/functions/list-provider-competitions/index.ts
+++ b/supabase/functions/list-provider-competitions/index.ts
@@ -4,19 +4,7 @@
 // no navegador. Apenas app_admin pode chamar.
 
 import { createClient } from "npm:@supabase/supabase-js@2";
-
-const cors = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-};
-
-function json(body: unknown, status = 200) {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { ...cors, "Content-Type": "application/json" },
-  });
-}
+import { corsHeaders } from "../_shared/security.ts";
 
 type ProviderCompetition = {
   provider: "football_data" | "thesportsdb" | "espn";
@@ -30,6 +18,12 @@ type ProviderCompetition = {
 };
 
 Deno.serve(async (req) => {
+  const cors = corsHeaders(req);
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { ...cors, "Content-Type": "application/json" },
+    });
   if (req.method === "OPTIONS") return new Response("ok", { headers: cors });
 
   const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
@@ -67,7 +61,8 @@ Deno.serve(async (req) => {
         headers: { "X-Auth-Token": fdToken },
       });
       if (!res.ok) {
-        return json({ error: `football-data ${res.status}: ${await res.text()}` }, 502);
+        console.error("football-data list error", res.status, await res.text());
+        return json({ error: `Provedor indisponível (${res.status}).` }, 502);
       }
       const data = await res.json();
       const competitions: ProviderCompetition[] = (data.competitions ?? []).map((c: {

--- a/supabase/functions/mercadopago-webhook/index.ts
+++ b/supabase/functions/mercadopago-webhook/index.ts
@@ -67,6 +67,7 @@ Deno.serve(async (req) => {
   const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
   const mpToken = Deno.env.get("MERCADOPAGO_ACCESS_TOKEN") ?? "";
   const webhookSecret = Deno.env.get("MP_WEBHOOK_SECRET") ?? "";
+  const admin = createClient(supabaseUrl, serviceKey, { auth: { persistSession: false } });
 
   // A notificação pode vir no body (JSON) e/ou na query string.
   const u = new URL(req.url);
@@ -90,9 +91,23 @@ Deno.serve(async (req) => {
   // Só tratamos eventos de pagamento.
   if (type !== "payment" || !dataId) return json({ ok: true, ignored: true });
 
+  // Rate limit por IP (endpoint público): freia abuso/amplificação.
+  const ip = (req.headers.get("x-forwarded-for") ?? "").split(",")[0]?.trim() || "unknown";
+  const { data: rlOk } = await admin.rpc("rate_limit_hit", {
+    p_bucket: `mpwh:${ip}`,
+    p_max: 120,
+    p_window_seconds: 60,
+  });
+  if (rlOk === false) return json({ error: "rate limited" }, 429);
+
   if (webhookSecret) {
     const ok = await validSignature(req, dataId, webhookSecret);
     if (!ok) return json({ error: "assinatura inválida" }, 401);
+    // Anti-replay: rejeita assinaturas com ts muito antigo (> 10 min).
+    const sigTs = Number((req.headers.get("x-signature") ?? "").match(/ts=([0-9]+)/)?.[1] ?? 0);
+    if (sigTs && Math.abs(Date.now() / 1000 - sigTs) > 600) {
+      return json({ error: "assinatura expirada" }, 401);
+    }
   }
   if (!mpToken) return json({ error: "token MP ausente" }, 503);
 
@@ -103,7 +118,7 @@ Deno.serve(async (req) => {
   if (!payRes.ok) return json({ error: `MP ${payRes.status}` }, 502);
   const pay = await payRes.json();
 
-  const meta = (pay.metadata ?? {}) as { league_id?: string; discount_code?: string };
+  const meta = (pay.metadata ?? {}) as { league_id?: string; user_id?: string; discount_code?: string };
   const leagueId: string | undefined = pay.external_reference ?? meta.league_id;
   if (!leagueId) return json({ ok: true, ignored: "sem external_reference" });
 
@@ -111,7 +126,38 @@ Deno.serve(async (req) => {
   const amountCents = Math.round(Number(pay.transaction_amount ?? 0) * 100);
   const preferenceId = pay.order?.id ? String(pay.order.id) : null;
 
-  const admin = createClient(supabaseUrl, serviceKey, { auth: { persistSession: false } });
+  // Só ativa se o PAGADOR for o dono da federação (fecha cross-league /
+  // external_reference forjado / pagamento de terceiro p/ liga alheia).
+  const { data: lg } = await admin
+    .from("leagues")
+    .select("owner_id")
+    .eq("id", leagueId)
+    .maybeSingle();
+  if (!lg) return json({ ok: true, ignored: "liga inexistente" });
+  if (status === "paid" && meta.user_id && meta.user_id !== lg.owner_id) {
+    console.error("webhook: payer != owner", { leagueId });
+    return json({ ok: true, ignored: "payer mismatch" });
+  }
+
+  // Sanidade de valor (sem cupom): rejeita ativação por valor muito abaixo do esperado.
+  if (status === "paid" && !meta.discount_code) {
+    const { data: st } = await admin
+      .from("app_settings")
+      .select("league_price_cents, promo_price_cents, promo_until")
+      .eq("id", 1)
+      .maybeSingle();
+    const baseCents = Number(st?.league_price_cents ?? 0);
+    const promoActive =
+      st?.promo_price_cents != null &&
+      st?.promo_until != null &&
+      new Date(st.promo_until).getTime() > Date.now();
+    const expected = promoActive ? Number(st?.promo_price_cents) : baseCents;
+    if (expected > 0 && amountCents + 50 < expected) {
+      console.error("webhook: valor abaixo do esperado", { leagueId, amountCents, expected });
+      return json({ ok: true, ignored: "amount below expected" });
+    }
+  }
+
   const { error } = await admin.rpc("confirm_league_payment", {
     p_league_id: leagueId,
     p_payment_id: String(pay.id),

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -5,20 +5,19 @@
 
 import webpush from "npm:web-push@3";
 import { createClient } from "npm:@supabase/supabase-js@2";
-
-const cors = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, content-type",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-};
+import { corsHeaders, timingSafeEqual } from "../_shared/security.ts";
 
 Deno.serve(async (req) => {
+  const cors = corsHeaders(req);
   if (req.method === "OPTIONS") return new Response("ok", { headers: cors });
 
   const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
   const cronSecret = Deno.env.get("CRON_SECRET") ?? "";
   const token = (req.headers.get("Authorization") ?? "").replace("Bearer ", "");
-  if (token !== serviceKey && !(cronSecret && token === cronSecret)) {
+  const authed =
+    (!!token && timingSafeEqual(token, serviceKey)) ||
+    (!!cronSecret && !!token && timingSafeEqual(token, cronSecret));
+  if (!authed) {
     return new Response(JSON.stringify({ error: "unauthorized" }), { status: 403, headers: cors });
   }
 

--- a/supabase/functions/sync-football/index.ts
+++ b/supabase/functions/sync-football/index.ts
@@ -6,12 +6,7 @@
 // Chamada agendada (cron): POST com a service_role key no Authorization.
 
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
-
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-};
+import { corsHeaders, timingSafeEqual } from "../_shared/security.ts";
 
 type MatchStatus = "scheduled" | "live" | "finished" | "postponed" | "cancelled";
 
@@ -21,13 +16,6 @@ interface CompetitionRow {
   provider: "manual" | "football_data" | "thesportsdb" | "espn";
   provider_code: string | null;
   provider_season: string | null;
-}
-
-function json(body: unknown, status = 200) {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { ...corsHeaders, "Content-Type": "application/json" },
-  });
 }
 
 // ---------------------------------------------------------------------------
@@ -125,7 +113,8 @@ async function syncFootballData(
 
   const res = await fetch(url, { headers: { "X-Auth-Token": token } });
   if (!res.ok) {
-    throw new Error(`football-data ${res.status}: ${await res.text()}`);
+    console.error("football-data sync error", res.status, await res.text());
+    throw new Error(`football-data indisponível (${res.status})`);
   }
   const data = await res.json();
   const matches: any[] = data.matches ?? [];
@@ -395,7 +384,10 @@ async function syncEspn(
 
   // 1) seed (hoje) → traz o calendar (datas com jogo)
   const seedRes = await fetch(`${base}?dates=${ymd(today)}`);
-  if (!seedRes.ok) throw new Error(`espn ${seedRes.status}: ${await seedRes.text()}`);
+  if (!seedRes.ok) {
+    console.error("espn sync error", seedRes.status, await seedRes.text());
+    throw new Error(`espn indisponível (${seedRes.status})`);
+  }
   const seed = await seedRes.json();
 
   // janela: -3 a +28 dias, dentro do calendar (teto de 30 requisições)
@@ -491,7 +483,13 @@ async function syncEspn(
 // Handler
 // ---------------------------------------------------------------------------
 Deno.serve(async (req) => {
-  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+  const cors = corsHeaders(req);
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { ...cors, "Content-Type": "application/json" },
+    });
+  if (req.method === "OPTIONS") return new Response("ok", { headers: cors });
 
   const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
   const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -506,7 +504,9 @@ Deno.serve(async (req) => {
   // Autorização: cron (service key ou CRON_SECRET) ou usuário app_admin
   const authHeader = req.headers.get("Authorization") ?? "";
   const jwt = authHeader.replace("Bearer ", "");
-  let authorized = jwt === serviceKey || (!!cronSecret && jwt === cronSecret);
+  let authorized =
+    (!!jwt && timingSafeEqual(jwt, serviceKey)) ||
+    (!!cronSecret && !!jwt && timingSafeEqual(jwt, cronSecret));
   if (!authorized && jwt) {
     const { data: userData } = await admin.auth.getUser(jwt);
     if (userData.user) {

--- a/supabase/migrations/20260603000020_security_confronto_reads.sql
+++ b/supabase/migrations/20260603000020_security_confronto_reads.sql
@@ -1,0 +1,446 @@
+-- ============================================================================
+-- Resultadismo · Segurança (code review v2) · Leituras de confronto + standings
+-- ----------------------------------------------------------------------------
+-- C1: as RPCs get_confronto_standings / get_confronto_ties / get_tie_detail eram
+--     SECURITY DEFINER concedidas a `anon` SEM checagem de visibilidade — qualquer
+--     um com um lc_id/tie_id lia o bracket de uma federação PRIVADA. Passa a gatear
+--     em is_app_admin() OR is_league_member() OR liga pública (igual get_league_standings).
+-- H6: enquanto o sorteio está 'scheduled' (agendado p/ revelar no futuro), as
+--     pairings NÃO podem vazar — get_confronto_ties / get_tie_detail retornam vazio
+--     para não-admins até a revelação.
+-- Medium: bye (member_b null) passa a valer vitória na classificação de confronto.
+-- Medium: get_league_standings protegida contra divisão por zero (cravada = 0).
+-- Medium: release_confronto_if_due deixa de ser anon e exige ser membro.
+-- (Mantém o anti-trapaça de palpites já existente em get_tie_detail.)
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- get_confronto_ties — pontos por período + GUARD (visibilidade + agendado)
+-- ---------------------------------------------------------------------------
+create or replace function public.get_confronto_ties(p_lc_id uuid)
+returns table (
+  id uuid, round_order int, round_label text, slot int, matchday int,
+  member_a uuid, member_b uuid, name_a text, name_b text, avatar_a text, avatar_b text,
+  pa int, pb int, winner uuid, resolved boolean, walkover boolean
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  with comp as (
+    select lc.competition_id, lc.league_id, lc.confronto_state, l.visibility
+    from public.league_competitions lc
+    join public.leagues l on l.id = lc.league_id
+    where lc.id = p_lc_id
+  ),
+  gate as (
+    select (
+      (public.is_app_admin()
+        or public.is_league_member(c.league_id)
+        or c.visibility = 'public')
+      and (c.confronto_state is distinct from 'scheduled'
+        or public.is_league_admin(c.league_id)
+        or public.is_app_admin())
+    ) as ok
+    from comp c
+  )
+  select
+    t.id, t.round_order, t.round_label, t.slot, t.matchday,
+    t.member_a, t.member_b,
+    pa_p.display_name, pb_p.display_name, pa_p.avatar_url, pb_p.avatar_url,
+    coalesce(a.pts, 0)::int as pa,
+    coalesce(b.pts, 0)::int as pb,
+    case
+      when t.member_b is null then t.member_a
+      when t.walkover_user is not null then
+        case when t.walkover_user = t.member_a then t.member_b else t.member_a end
+      when not pl.played then null
+      when coalesce(a.pts, 0) > coalesce(b.pts, 0) then t.member_a
+      when coalesce(b.pts, 0) > coalesce(a.pts, 0) then t.member_b
+      else null
+    end as winner,
+    (t.walkover_user is not null or pl.played) as resolved,
+    (t.walkover_user is not null) as walkover
+  from public.cup_ties t
+  left join public.profiles pa_p on pa_p.id = t.member_a
+  left join public.profiles pb_p on pb_p.id = t.member_b
+  left join lateral (
+    select sum(coalesce(public.score_points(pr.score_type), 0)
+               * (case when pr.is_joker then 2 else 1 end))::int as pts
+    from public.matches m
+    join comp on m.competition_id = comp.competition_id
+    join public.predictions pr on pr.match_id = m.id and pr.user_id = t.member_a
+    where m.status = 'finished'
+      and public.match_in_period(t.period_kind, t.period_value, t.matchday, m.matchday, m.stage, m.kickoff_at)
+  ) a on true
+  left join lateral (
+    select sum(coalesce(public.score_points(pr.score_type), 0)
+               * (case when pr.is_joker then 2 else 1 end))::int as pts
+    from public.matches m
+    join comp on m.competition_id = comp.competition_id
+    join public.predictions pr on pr.match_id = m.id and pr.user_id = t.member_b
+    where m.status = 'finished'
+      and public.match_in_period(t.period_kind, t.period_value, t.matchday, m.matchday, m.stage, m.kickoff_at)
+  ) b on true
+  left join lateral (
+    select exists (
+      select 1 from public.matches m
+      join comp on m.competition_id = comp.competition_id
+      where m.status = 'finished'
+        and public.match_in_period(t.period_kind, t.period_value, t.matchday, m.matchday, m.stage, m.kickoff_at)
+    ) as played
+  ) pl on true
+  where t.league_competition_id = p_lc_id
+    and (select ok from gate)
+  order by t.round_order, t.slot;
+$$;
+grant execute on function public.get_confronto_ties(uuid) to anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- get_confronto_standings — 3/1/0 por período + GUARD + bye = vitória
+-- ---------------------------------------------------------------------------
+create or replace function public.get_confronto_standings(p_lc_id uuid)
+returns table (
+  user_id uuid, display_name text, avatar_url text,
+  jogos int, vitorias int, empates int, derrotas int,
+  pontos int, gols_pro int, gols_contra int, rank int
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  with lc as (
+    select lc.id, lc.league_id, lc.competition_id, lc.confronto_state, l.visibility
+    from public.league_competitions lc
+    join public.leagues l on l.id = lc.league_id
+    where lc.id = p_lc_id
+  ),
+  gate as (
+    select (
+      (public.is_app_admin()
+        or public.is_league_member(lc.league_id)
+        or lc.visibility = 'public')
+      and (lc.confronto_state is distinct from 'scheduled'
+        or public.is_league_admin(lc.league_id)
+        or public.is_app_admin())
+    ) as ok
+    from lc
+  ),
+  scored as (
+    select
+      t.member_a, t.member_b, t.walkover_user,
+      coalesce(a.pts, 0) as pa, coalesce(b.pts, 0) as pb,
+      pl.played
+    from public.cup_ties t
+    join lc on t.league_competition_id = lc.id
+    left join lateral (
+      select sum(coalesce(public.score_points(pr.score_type), 0)
+                 * (case when pr.is_joker then 2 else 1 end))::int as pts
+      from public.matches m
+      join public.predictions pr on pr.match_id = m.id and pr.user_id = t.member_a
+      where m.competition_id = lc.competition_id and m.status = 'finished'
+        and public.match_in_period(t.period_kind, t.period_value, t.matchday, m.matchday, m.stage, m.kickoff_at)
+    ) a on true
+    left join lateral (
+      select sum(coalesce(public.score_points(pr.score_type), 0)
+                 * (case when pr.is_joker then 2 else 1 end))::int as pts
+      from public.matches m
+      join public.predictions pr on pr.match_id = m.id and pr.user_id = t.member_b
+      where m.competition_id = lc.competition_id and m.status = 'finished'
+        and public.match_in_period(t.period_kind, t.period_value, t.matchday, m.matchday, m.stage, m.kickoff_at)
+    ) b on true
+    left join lateral (
+      select exists (
+        select 1 from public.matches m
+        where m.competition_id = lc.competition_id and m.status = 'finished'
+          and public.match_in_period(t.period_kind, t.period_value, t.matchday, m.matchday, m.stage, m.kickoff_at)
+      ) as played
+    ) pl on true
+    where t.member_b is not null
+  ),
+  byes as (
+    -- Bye (sem adversário) conta como vitória para quem ficou de fora da rodada.
+    select t.member_a as uid
+    from public.cup_ties t
+    join lc on t.league_competition_id = lc.id
+    where t.member_b is null and t.member_a is not null
+  ),
+  ties as (
+    select member_a, member_b, pa, pb from scored
+    where walkover_user is null and played
+  ),
+  wo as (
+    select case when walkover_user = member_a then member_b else member_a end as winner_uid
+    from scored where walkover_user is not null
+  ),
+  results as (
+    select member_a as uid,
+           case when pa > pb then 3 when pa = pb then 1 else 0 end as pts,
+           (pa > pb)::int as v, (pa = pb)::int as e, (pa < pb)::int as d, pa as gp, pb as gc
+    from ties
+    union all
+    select member_b as uid,
+           case when pb > pa then 3 when pa = pb then 1 else 0 end as pts,
+           (pb > pa)::int as v, (pa = pb)::int as e, (pb < pa)::int as d, pb as gp, pa as gc
+    from ties
+    union all
+    select winner_uid as uid, 3 as pts, 1 as v, 0 as e, 0 as d, 1 as gp, 0 as gc from wo
+    union all
+    select uid, 3 as pts, 1 as v, 0 as e, 0 as d, 1 as gp, 0 as gc from byes
+  ),
+  agg as (
+    select uid, count(*)::int as jogos, sum(v)::int as vitorias, sum(e)::int as empates,
+           sum(d)::int as derrotas, sum(pts)::int as pontos,
+           sum(gp)::int as gols_pro, sum(gc)::int as gols_contra
+    from results group by uid
+  )
+  select
+    mem.user_id, pr.display_name, pr.avatar_url,
+    coalesce(a.jogos, 0), coalesce(a.vitorias, 0), coalesce(a.empates, 0),
+    coalesce(a.derrotas, 0), coalesce(a.pontos, 0), coalesce(a.gols_pro, 0), coalesce(a.gols_contra, 0),
+    (row_number() over (
+      order by coalesce(a.pontos, 0) desc,
+               (coalesce(a.gols_pro, 0) - coalesce(a.gols_contra, 0)) desc,
+               coalesce(a.gols_pro, 0) desc, mem.joined_at asc
+    ))::int as rank
+  from public.league_members mem
+  join public.profiles pr on pr.id = mem.user_id
+  left join agg a on a.uid = mem.user_id
+  where mem.league_id = (select league_id from lc)
+    and mem.status = 'active'
+    and (select ok from gate)
+  order by rank;
+$$;
+grant execute on function public.get_confronto_standings(uuid) to anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- get_tie_detail — jogos do período + GUARD (visibilidade + agendado).
+-- Mantém o anti-trapaça (palpite do adversário só após kickoff).
+-- ---------------------------------------------------------------------------
+create or replace function public.get_tie_detail(p_tie_id uuid)
+returns table (
+  match_id uuid, kickoff_at timestamptz, status public.match_status,
+  home_name text, away_name text, home_score int, away_score int,
+  a_home int, a_away int, a_pts int, a_joker boolean,
+  b_home int, b_away int, b_pts int, b_joker boolean,
+  a_palpitou boolean, b_palpitou boolean
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  with t as (
+    select league_competition_id, matchday, period_kind, period_value, member_a, member_b
+    from public.cup_ties where id = p_tie_id
+  ),
+  lc as (
+    select lc.competition_id, lc.league_id, lc.confronto_state, l.visibility
+    from public.league_competitions lc
+    join public.leagues l on l.id = lc.league_id
+    where lc.id = (select league_competition_id from t)
+  ),
+  gate as (
+    select (
+      (public.is_app_admin()
+        or public.is_league_member(lc.league_id)
+        or lc.visibility = 'public')
+      and (lc.confronto_state is distinct from 'scheduled'
+        or public.is_league_admin(lc.league_id)
+        or public.is_app_admin())
+    ) as ok
+    from lc
+  )
+  select
+    m.id, m.kickoff_at, m.status,
+    coalesce(ht.short_name, m.home_team_name),
+    coalesce(at.short_name, m.away_team_name),
+    m.home_score, m.away_score,
+    case when r.rev_a then pa.home_pred end,
+    case when r.rev_a then pa.away_pred end,
+    case when r.rev_a then (coalesce(public.score_points(pa.score_type), 0) * (case when pa.is_joker then 2 else 1 end)) end,
+    case when r.rev_a then coalesce(pa.is_joker, false) else false end,
+    case when r.rev_b then pb.home_pred end,
+    case when r.rev_b then pb.away_pred end,
+    case when r.rev_b then (coalesce(public.score_points(pb.score_type), 0) * (case when pb.is_joker then 2 else 1 end)) end,
+    case when r.rev_b then coalesce(pb.is_joker, false) else false end,
+    (pa.home_pred is not null),
+    (pb.home_pred is not null)
+  from public.matches m
+  join lc on m.competition_id = lc.competition_id
+  left join public.teams ht on ht.id = m.home_team_id
+  left join public.teams at on at.id = m.away_team_id
+  left join public.predictions pa on pa.match_id = m.id and pa.user_id = (select member_a from t)
+  left join public.predictions pb on pb.match_id = m.id and pb.user_id = (select member_b from t)
+  cross join lateral (
+    select
+      ((m.kickoff_at is not null and m.kickoff_at <= now()) or (select member_a from t) = auth.uid()) as rev_a,
+      ((m.kickoff_at is not null and m.kickoff_at <= now()) or (select member_b from t) = auth.uid()) as rev_b
+  ) r
+  where public.match_in_period(
+          (select period_kind from t), (select period_value from t), (select matchday from t),
+          m.matchday, m.stage, m.kickoff_at)
+    and (select ok from gate)
+  order by m.kickoff_at;
+$$;
+grant execute on function public.get_tie_detail(uuid) to anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- get_league_standings — protege contra divisão por zero quando cravada = 0
+-- (settings.points.cravada é editável pelo admin da liga).
+-- ---------------------------------------------------------------------------
+create or replace function public.get_league_standings(p_lc_id uuid)
+returns table (
+  user_id uuid,
+  display_name text,
+  avatar_url text,
+  jogos int,
+  pontos int,
+  cravadas int,
+  saldos int,
+  acertos int,
+  erros int,
+  aproveitamento numeric,
+  acertividade numeric,
+  rank int
+)
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  v_league_id uuid;
+  v_competition_id uuid;
+  v_starts_on date;
+  v_visibility public.league_visibility;
+  v_p_cravada int;
+  v_p_saldo int;
+  v_p_acerto int;
+begin
+  select lc.league_id, lc.competition_id, lc.starts_on,
+         coalesce((lc.settings -> 'points' ->> 'cravada')::int, 3),
+         coalesce((lc.settings -> 'points' ->> 'saldo')::int, 2),
+         coalesce((lc.settings -> 'points' ->> 'acerto')::int, 1)
+    into v_league_id, v_competition_id, v_starts_on, v_p_cravada, v_p_saldo, v_p_acerto
+  from public.league_competitions lc
+  where lc.id = p_lc_id;
+
+  if v_league_id is null then
+    return;
+  end if;
+
+  -- nunca deixa o divisor zerar (aproveitamento usa v_p_cravada * jogos)
+  if coalesce(v_p_cravada, 0) <= 0 then
+    v_p_cravada := 3;
+  end if;
+
+  select l.visibility into v_visibility from public.leagues l where l.id = v_league_id;
+
+  if not (public.is_app_admin()
+          or public.is_league_member(v_league_id)
+          or v_visibility = 'public') then
+    return;
+  end if;
+
+  return query
+  with members as (
+    select lm.user_id, p.display_name, p.avatar_url, p.created_at
+    from public.league_members lm
+    join public.profiles p on p.id = lm.user_id
+    where lm.league_id = v_league_id and lm.status = 'active'
+  ),
+  scored as (
+    select pr.user_id, pr.score_type, pr.is_joker
+    from public.predictions pr
+    join public.matches m on m.id = pr.match_id
+    where m.competition_id = v_competition_id
+      and m.status = 'finished'
+      and pr.score_type is not null
+      and (v_starts_on is null or m.kickoff_at::date >= v_starts_on)
+  ),
+  agg as (
+    select s.user_id,
+      count(*)::int as jogos,
+      sum(
+        (case s.score_type
+            when 'cravada' then v_p_cravada
+            when 'saldo' then v_p_saldo
+            when 'acerto' then v_p_acerto
+            else 0 end)
+        * (case when s.is_joker then 2 else 1 end)
+      )::int as pontos,
+      count(*) filter (where s.score_type = 'cravada')::int as cravadas,
+      count(*) filter (where s.score_type = 'saldo')::int as saldos,
+      count(*) filter (where s.score_type = 'acerto')::int as acertos,
+      count(*) filter (where s.score_type = 'erro')::int as erros
+    from scored s
+    group by s.user_id
+  )
+  select
+    mem.user_id,
+    mem.display_name,
+    mem.avatar_url,
+    coalesce(a.jogos, 0),
+    coalesce(a.pontos, 0),
+    coalesce(a.cravadas, 0),
+    coalesce(a.saldos, 0),
+    coalesce(a.acertos, 0),
+    coalesce(a.erros, 0),
+    case when coalesce(a.jogos, 0) = 0 then 0
+         else round(coalesce(a.pontos, 0)::numeric / (v_p_cravada * a.jogos) * 100, 1) end,
+    case when coalesce(a.jogos, 0) = 0 then 0
+         else round((a.cravadas + a.saldos + a.acertos)::numeric / a.jogos * 100, 1) end,
+    (row_number() over (
+      order by
+        coalesce(a.pontos, 0) desc,
+        coalesce(a.cravadas, 0) desc,
+        coalesce(a.saldos, 0) desc,
+        (case when coalesce(a.jogos, 0) = 0 then 0
+              else coalesce(a.pontos, 0)::numeric / (v_p_cravada * a.jogos) end) desc,
+        (case when coalesce(a.jogos, 0) = 0 then 0
+              else (a.cravadas + a.saldos + a.acertos)::numeric / a.jogos end) desc,
+        mem.created_at asc
+    ))::int as rank
+  from members mem
+  left join agg a on a.user_id = mem.user_id
+  order by rank;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- release_confronto_if_due — deixa de ser anon; exige ser membro da federação.
+-- (continua só revelando quando o horário já chegou).
+-- ---------------------------------------------------------------------------
+create or replace function public.release_confronto_if_due(p_lc_id uuid)
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_done boolean := false;
+  v_league uuid;
+begin
+  select league_id into v_league from public.league_competitions where id = p_lc_id;
+  if v_league is null then
+    return false;
+  end if;
+  if not (public.is_league_member(v_league) or public.is_app_admin()) then
+    return false;
+  end if;
+
+  update public.league_competitions
+     set confronto_state = 'drawn', drawn_at = now()
+   where id = p_lc_id
+     and confronto_state = 'scheduled'
+     and scheduled_draw_at is not null
+     and scheduled_draw_at <= now();
+  get diagnostics v_done = row_count;
+  return v_done;
+end;
+$$;
+revoke all on function public.release_confronto_if_due(uuid) from public, anon;
+grant execute on function public.release_confronto_if_due(uuid) to authenticated;

--- a/supabase/migrations/20260603000021_security_payments.sql
+++ b/supabase/migrations/20260603000021_security_payments.sql
@@ -1,0 +1,174 @@
+-- ============================================================================
+-- Resultadismo · Segurança (code review v2) · Pagamentos / reembolso
+-- ----------------------------------------------------------------------------
+-- C2: confirm_league_payment não tinha guarda de estado terminal — um evento
+--     'paid' reentregue/fora de ordem DEPOIS de um reembolso reativava a federação
+--     (dinheiro já devolvido + federação ativa de graça). Agora:
+--       - trava a linha da liga (select ... for update) → serializa com o reembolso;
+--       - uma vez 'refunded', NÃO volta para 'paid' (idempotente).
+-- H3: simulate_league_payment (pagamento fake do modo teste) passa a exigir
+--     is_app_admin() — no modo 'live' o front usa o checkout real; em test/dev só
+--     admins simulam. Fecha o buraco de "modo teste em prod = federação grátis".
+-- Medium: cupom (max_uses) contado de forma atômica (não estoura o limite).
+-- Medium: league_payments.amount_cents >= 0.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- confirm_league_payment — guarda de estado terminal + lock da linha.
+-- ---------------------------------------------------------------------------
+create or replace function public.confirm_league_payment(
+  p_league_id uuid,
+  p_payment_id text,
+  p_status public.payment_status,
+  p_amount_cents int default null,
+  p_preference_id text default null,
+  p_raw jsonb default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_owner uuid;
+  v_current public.payment_status;
+begin
+  if not public.can_settle_leagues() then
+    raise exception 'Sem permissão para confirmar pagamento.';
+  end if;
+
+  -- trava a liga: serializa com reembolso concorrente / webhooks fora de ordem
+  select owner_id, payment_status into v_owner, v_current
+  from public.leagues where id = p_league_id
+  for update;
+
+  if v_owner is null then
+    raise exception 'Liga % não encontrada.', p_league_id;
+  end if;
+
+  -- ESTADO TERMINAL: já reembolsada não volta a 'paid' (idempotente).
+  -- Só registra o evento bruto p/ auditoria, sem reativar a federação.
+  if v_current = 'refunded' and p_status = 'paid' then
+    update public.league_payments
+      set raw = coalesce(p_raw, raw), updated_at = now()
+      where league_id = p_league_id and payment_id = p_payment_id;
+    return;
+  end if;
+
+  -- registra/atualiza o pagamento (idempotente por provider+payment_id)
+  insert into public.league_payments
+    (league_id, user_id, payment_id, preference_id, external_reference,
+     status, amount_cents, raw)
+  values
+    (p_league_id, v_owner, p_payment_id, p_preference_id, p_league_id::text,
+     p_status, coalesce(p_amount_cents, 0), p_raw)
+  on conflict (provider, payment_id) where payment_id is not null
+  do update set status        = case
+                                  when public.league_payments.status = 'refunded' and excluded.status = 'paid'
+                                  then public.league_payments.status
+                                  else excluded.status end,
+                raw           = excluded.raw,
+                amount_cents  = excluded.amount_cents,
+                preference_id = coalesce(excluded.preference_id, public.league_payments.preference_id),
+                updated_at    = now();
+
+  -- reflete o status na federação:
+  --   paid     → ativa (e manda o nome p/ revisão)
+  --   refunded → arquiva (soft-delete) = reembolso/arrependimento
+  update public.leagues
+  set payment_status = case when v_current = 'refunded' and p_status = 'paid' then v_current else p_status end,
+      status      = case
+                      when p_status = 'paid' and v_current <> 'refunded' then 'active'
+                      when p_status = 'refunded' then 'archived'
+                      else status end,
+      approved_at = case when p_status = 'paid' then coalesce(approved_at, now()) else approved_at end,
+      name_approved = case when p_status = 'paid' and v_current <> 'refunded' then false else name_approved end,
+      deleted_at  = case when p_status = 'refunded' then coalesce(deleted_at, now()) else deleted_at end
+  where id = p_league_id;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- simulate_league_payment — agora exige is_app_admin() (além do modo teste).
+-- ---------------------------------------------------------------------------
+create or replace function public.simulate_league_payment(
+  p_league_id uuid,
+  p_discount_code text default null
+)
+returns public.leagues
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v public.leagues;
+  v_owner uuid;
+  v_mode public.payment_mode;
+begin
+  -- só administradores do app podem simular pagamento (evita "modo teste = grátis")
+  if not public.is_app_admin() then
+    raise exception 'Simulação de pagamento disponível apenas para administradores.';
+  end if;
+
+  select payment_mode into v_mode from public.app_settings where id = 1;
+  if coalesce(v_mode, 'disabled') <> 'test' then
+    raise exception 'Simulação disponível apenas no modo de teste.';
+  end if;
+  select owner_id into v_owner from public.leagues where id = p_league_id;
+  if v_owner is null then
+    raise exception 'Federação não encontrada.';
+  end if;
+
+  perform set_config('app.settle_bypass', '1', true);
+
+  insert into public.league_payments
+    (league_id, user_id, provider, payment_id, status, amount_cents, discount_code)
+  values
+    (p_league_id, v_owner, 'test', 'test-' || p_league_id::text, 'paid', 0,
+     upper(nullif(trim(coalesce(p_discount_code, '')), '')))
+  on conflict (provider, payment_id) where payment_id is not null
+  do update set status = 'paid';
+
+  update public.leagues
+    set payment_status = 'paid', status = 'active', approved_at = coalesce(approved_at, now()),
+        name_approved = false
+    where id = p_league_id
+  returning * into v;
+  return v;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Cupom: conta o uso de forma ATÔMICA — nunca passa de max_uses.
+-- ---------------------------------------------------------------------------
+create or replace function public.league_payments_count_discount()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if new.status = 'paid' and new.discount_code is not null and not new.discount_counted then
+    update public.discount_codes
+      set used_count = used_count + 1
+      where code = upper(new.discount_code)
+        and (max_uses is null or used_count < max_uses);
+    new.discount_counted := true;
+  end if;
+  return new;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Integridade: valor do pagamento não pode ser negativo.
+-- ---------------------------------------------------------------------------
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'league_payments_amount_nonneg'
+  ) then
+    alter table public.league_payments
+      add constraint league_payments_amount_nonneg check (amount_cents >= 0);
+  end if;
+end
+$$;

--- a/supabase/migrations/20260603000022_security_confronto_writes.sql
+++ b/supabase/migrations/20260603000022_security_confronto_writes.sql
@@ -1,0 +1,285 @@
+-- ============================================================================
+-- Resultadismo · Segurança (code review v2) · Escrita de confronto (cup_ties)
+-- ----------------------------------------------------------------------------
+-- C4: a policy cup_ties_write_admin dava INSERT/UPDATE/DELETE direto na tabela a
+--     qualquer admin de liga (que TAMBÉM compete) — dava p/ forjar walkover,
+--     reescrever pares/placar depois dos jogos, apagar confrontos perdidos,
+--     burlando as RPCs. Removemos a escrita direta: tudo passa a ser só via RPC
+--     SECURITY DEFINER (draw/undo/append/leave/advance), que validam estado e papel.
+-- H4: draw_confronto / append_confronto_ties passam a VALIDAR os confrontos —
+--     só participantes/membros ativos, sem jogador contra si mesmo.
+-- H5: Copa (mata-mata) — advance_confronto_cup promove o vencedor de cada chave
+--     para a próxima fase (antes os slots ficavam vazios p/ sempre). Desempate de
+--     mata-mata pelo melhor seed.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- C4 — remove a escrita direta na tabela (mantém só a leitura via policy).
+-- ---------------------------------------------------------------------------
+drop policy if exists "cup_ties_write_admin" on public.cup_ties;
+
+-- ---------------------------------------------------------------------------
+-- H4 — draw_confronto com validação (membros ativos, sem auto-pareamento).
+-- ---------------------------------------------------------------------------
+create or replace function public.draw_confronto(
+  p_lc_id uuid,
+  p_participants jsonb,
+  p_ties jsonb,
+  p_liga_format text default null,
+  p_period_kind text default null,
+  p_scheduled_draw_at timestamptz default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_league uuid;
+  v_scheduled boolean := p_scheduled_draw_at is not null and p_scheduled_draw_at > now();
+begin
+  select league_id into v_league from public.league_competitions where id = p_lc_id;
+  if v_league is null then
+    raise exception 'Disputa não encontrada.';
+  end if;
+  if not (public.is_league_admin(v_league) or public.is_app_admin()) then
+    raise exception 'Apenas administradores da federação podem sortear.';
+  end if;
+
+  -- Validação: todo participante precisa ser membro ATIVO da federação.
+  if exists (
+    select 1 from jsonb_array_elements(p_participants) e
+    where not exists (
+      select 1 from public.league_members lm
+      where lm.league_id = v_league and lm.status = 'active'
+        and lm.user_id = (e ->> 'user_id')::uuid
+    )
+  ) then
+    raise exception 'Há participante que não é membro ativo da federação.';
+  end if;
+
+  -- Validação: ninguém joga contra si mesmo.
+  if exists (
+    select 1 from jsonb_array_elements(p_ties) e
+    where nullif(e ->> 'member_a', '') is not null
+      and nullif(e ->> 'member_b', '') is not null
+      and (e ->> 'member_a') = (e ->> 'member_b')
+  ) then
+    raise exception 'Confronto inválido: jogador contra si mesmo.';
+  end if;
+
+  -- Validação: confrontos só entre participantes do sorteio.
+  if exists (
+    select 1
+    from jsonb_array_elements(p_ties) e
+    cross join lateral (values (nullif(e ->> 'member_a', '')), (nullif(e ->> 'member_b', ''))) as m(uid)
+    where m.uid is not null
+      and not exists (
+        select 1 from jsonb_array_elements(p_participants) p
+        where p ->> 'user_id' = m.uid
+      )
+  ) then
+    raise exception 'Confronto com jogador fora da lista de participantes.';
+  end if;
+
+  delete from public.cup_ties where league_competition_id = p_lc_id;
+  delete from public.confronto_participants where league_competition_id = p_lc_id;
+
+  insert into public.confronto_participants (league_competition_id, user_id, seed)
+  select p_lc_id, (e ->> 'user_id')::uuid, coalesce((e ->> 'seed')::int, 0)
+  from jsonb_array_elements(p_participants) e;
+
+  insert into public.cup_ties
+    (league_competition_id, round_order, round_label, slot, member_a, member_b,
+     matchday, period_kind, period_value, status)
+  select p_lc_id,
+         (e ->> 'round_order')::int,
+         e ->> 'round_label',
+         (e ->> 'slot')::int,
+         nullif(e ->> 'member_a', '')::uuid,
+         nullif(e ->> 'member_b', '')::uuid,
+         nullif(e ->> 'matchday', '')::int,
+         nullif(e ->> 'period_kind', ''),
+         nullif(e ->> 'period_value', ''),
+         'pending'
+  from jsonb_array_elements(p_ties) e;
+
+  update public.league_competitions
+     set confronto_state = case when v_scheduled then 'scheduled' else 'drawn' end,
+         drawn_at = case when v_scheduled then null else now() end,
+         scheduled_draw_at = case when v_scheduled then p_scheduled_draw_at else null end,
+         liga_format = coalesce(p_liga_format, liga_format),
+         period_kind = coalesce(p_period_kind, period_kind)
+   where id = p_lc_id;
+end;
+$$;
+grant execute on function public.draw_confronto(uuid, jsonb, jsonb, text, text, timestamptz) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- H4 — append_confronto_ties com validação (só participantes; sem auto-pareamento).
+-- ---------------------------------------------------------------------------
+create or replace function public.append_confronto_ties(p_lc_id uuid, p_ties jsonb)
+returns int
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_league uuid;
+  v_state text;
+  v_n int;
+begin
+  select league_id, confronto_state into v_league, v_state
+  from public.league_competitions where id = p_lc_id;
+  if v_league is null then
+    raise exception 'Disputa não encontrada.';
+  end if;
+  if not (public.is_league_admin(v_league) or public.is_app_admin()) then
+    raise exception 'Apenas administradores da federação podem gerar rodadas.';
+  end if;
+  if v_state <> 'drawn' then
+    raise exception 'A disputa não está em andamento.';
+  end if;
+
+  if exists (
+    select 1 from jsonb_array_elements(p_ties) e
+    where nullif(e ->> 'member_a', '') is not null
+      and nullif(e ->> 'member_b', '') is not null
+      and (e ->> 'member_a') = (e ->> 'member_b')
+  ) then
+    raise exception 'Confronto inválido: jogador contra si mesmo.';
+  end if;
+
+  if exists (
+    select 1
+    from jsonb_array_elements(p_ties) e
+    cross join lateral (values (nullif(e ->> 'member_a', '')), (nullif(e ->> 'member_b', ''))) as m(uid)
+    where m.uid is not null
+      and not exists (
+        select 1 from public.confronto_participants cp
+        where cp.league_competition_id = p_lc_id and cp.user_id = m.uid::uuid
+      )
+  ) then
+    raise exception 'Confronto com jogador fora dos participantes.';
+  end if;
+
+  insert into public.cup_ties
+    (league_competition_id, round_order, round_label, slot, member_a, member_b,
+     matchday, period_kind, period_value, status)
+  select p_lc_id,
+         (e ->> 'round_order')::int,
+         e ->> 'round_label',
+         (e ->> 'slot')::int,
+         nullif(e ->> 'member_a', '')::uuid,
+         nullif(e ->> 'member_b', '')::uuid,
+         nullif(e ->> 'matchday', '')::int,
+         nullif(e ->> 'period_kind', ''),
+         nullif(e ->> 'period_value', ''),
+         'pending'
+  from jsonb_array_elements(p_ties) e;
+  get diagnostics v_n = row_count;
+  return v_n;
+end;
+$$;
+revoke all on function public.append_confronto_ties(uuid, jsonb) from public, anon;
+grant execute on function public.append_confronto_ties(uuid, jsonb) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- H5 — Copa: avança o vencedor de cada chave para a fase seguinte.
+-- Idempotente (só preenche slot vazio). Bye avança na hora. Empate no mata-mata
+-- é desempatado pelo melhor seed (menor número). Chamada de forma "lazy" pelo
+-- front ao abrir o chaveamento + pelo backstop de release.
+-- ---------------------------------------------------------------------------
+create or replace function public.advance_confronto_cup(p_lc_id uuid)
+returns int
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_league uuid;
+  v_comp uuid;
+  v_total int := 0;
+  v_n int;
+  v_iter int := 0;
+begin
+  select league_id, competition_id into v_league, v_comp
+  from public.league_competitions where id = p_lc_id;
+  if v_league is null then
+    return 0;
+  end if;
+  if not (public.is_league_member(v_league) or public.is_app_admin()) then
+    return 0;
+  end if;
+
+  loop
+    v_iter := v_iter + 1;
+    exit when v_iter > 12; -- backstop: brackets têm poucas fases
+
+    with seeds as (
+      select user_id, seed from public.confronto_participants
+      where league_competition_id = p_lc_id
+    ),
+    resolved as (
+      select
+        t.round_order, t.slot,
+        case
+          when t.member_b is null then t.member_a
+          when t.walkover_user is not null then
+            case when t.walkover_user = t.member_a then t.member_b else t.member_a end
+          when not pl.played then null
+          when coalesce(a.pts, 0) > coalesce(b.pts, 0) then t.member_a
+          when coalesce(b.pts, 0) > coalesce(a.pts, 0) then t.member_b
+          else case when coalesce(sa.seed, 2147483647) <= coalesce(sb.seed, 2147483647)
+                    then t.member_a else t.member_b end
+        end as winner
+      from public.cup_ties t
+      left join seeds sa on sa.user_id = t.member_a
+      left join seeds sb on sb.user_id = t.member_b
+      left join lateral (
+        select sum(coalesce(public.score_points(pr.score_type), 0)
+                   * (case when pr.is_joker then 2 else 1 end))::int as pts
+        from public.matches m
+        join public.predictions pr on pr.match_id = m.id and pr.user_id = t.member_a
+        where m.competition_id = v_comp and m.status = 'finished'
+          and public.match_in_period(t.period_kind, t.period_value, t.matchday, m.matchday, m.stage, m.kickoff_at)
+      ) a on true
+      left join lateral (
+        select sum(coalesce(public.score_points(pr.score_type), 0)
+                   * (case when pr.is_joker then 2 else 1 end))::int as pts
+        from public.matches m
+        join public.predictions pr on pr.match_id = m.id and pr.user_id = t.member_b
+        where m.competition_id = v_comp and m.status = 'finished'
+          and public.match_in_period(t.period_kind, t.period_value, t.matchday, m.matchday, m.stage, m.kickoff_at)
+      ) b on true
+      left join lateral (
+        select exists (
+          select 1 from public.matches m
+          where m.competition_id = v_comp and m.status = 'finished'
+            and public.match_in_period(t.period_kind, t.period_value, t.matchday, m.matchday, m.stage, m.kickoff_at)
+        ) as played
+      ) pl on true
+      where t.league_competition_id = p_lc_id
+    )
+    update public.cup_ties pt
+    set member_a = case when (r.slot % 2) = 1 then r.winner else pt.member_a end,
+        member_b = case when (r.slot % 2) = 0 then r.winner else pt.member_b end
+    from resolved r
+    where pt.league_competition_id = p_lc_id
+      and pt.round_order = r.round_order + 1
+      and pt.slot = ((r.slot + 1) / 2)
+      and r.winner is not null
+      and (
+        ((r.slot % 2) = 1 and pt.member_a is null)
+        or ((r.slot % 2) = 0 and pt.member_b is null)
+      );
+    get diagnostics v_n = row_count;
+    v_total := v_total + v_n;
+    exit when v_n = 0;
+  end loop;
+
+  return v_total;
+end;
+$$;
+revoke all on function public.advance_confronto_cup(uuid) from public, anon;
+grant execute on function public.advance_confronto_cup(uuid) to authenticated;

--- a/supabase/migrations/20260603000023_security_joker_race.sql
+++ b/supabase/migrations/20260603000023_security_joker_race.sql
@@ -1,0 +1,53 @@
+-- ============================================================================
+-- Resultadismo · Segurança (code review v2) · Joker / Dobro — corrida (TOCTOU)
+-- ----------------------------------------------------------------------------
+-- O limite "2 dobros por semana" era checado por count() sem serialização: dois
+-- updates concorrentes (mesma semana, jogos diferentes) liam o mesmo count e
+-- ambos passavam → 3+ dobros. Agora pegamos um advisory lock transacional por
+-- (usuário, competição, semana) ANTES da contagem, serializando a verificação.
+-- ============================================================================
+
+create or replace function public.enforce_joker_limit()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_comp uuid;
+  v_week date;
+  v_per_week int;
+  v_count int;
+begin
+  if new.is_joker is true then
+    select m.competition_id,
+           (date_trunc('week', (m.kickoff_at at time zone 'America/Sao_Paulo')))::date
+      into v_comp, v_week
+    from public.matches m
+    where m.id = new.match_id;
+
+    -- Serializa a verificação para esta (user, competição, semana).
+    perform pg_advisory_xact_lock(
+      hashtext(new.user_id::text || ':' || coalesce(v_comp::text, '') || ':' || coalesce(v_week::text, ''))
+    );
+
+    select coalesce(jokers_per_week, 2) into v_per_week
+    from public.competitions
+    where id = v_comp;
+
+    select count(*) into v_count
+    from public.predictions p
+    join public.matches m on m.id = p.match_id
+    where p.user_id = new.user_id
+      and p.is_joker = true
+      and p.id <> new.id
+      and m.competition_id = v_comp
+      and (date_trunc('week', (m.kickoff_at at time zone 'America/Sao_Paulo')))::date = v_week;
+
+    if v_count >= v_per_week then
+      raise exception 'Você já usou seus % dobros nesta semana.', v_per_week;
+    end if;
+  end if;
+  return new;
+end;
+$$;

--- a/supabase/migrations/20260603000024_rate_limit.sql
+++ b/supabase/migrations/20260603000024_rate_limit.sql
@@ -1,0 +1,52 @@
+-- ============================================================================
+-- Resultadismo · Segurança (code review v2) · Rate limit (janela fixa)
+-- ----------------------------------------------------------------------------
+-- Endpoints que disparam fetch a APIs pagas/limitadas ou são públicos (webhook)
+-- não tinham throttle. rate_limit_hit faz uma janela fixa atômica por "bucket"
+-- (ex.: ip da webhook, uid do checkout) e devolve false quando estourou.
+-- Só service_role chama (as Edge Functions usam a chave de serviço).
+-- ============================================================================
+
+create table if not exists public.rate_limits (
+  bucket text primary key,
+  window_start timestamptz not null default now(),
+  count int not null default 0
+);
+
+alter table public.rate_limits enable row level security;
+-- sem policies: ninguém (anon/authenticated) acessa direto; só service_role/definer.
+
+create or replace function public.rate_limit_hit(
+  p_bucket text,
+  p_max int,
+  p_window_seconds int
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_count int;
+begin
+  insert into public.rate_limits (bucket, window_start, count)
+  values (p_bucket, now(), 1)
+  on conflict (bucket) do update
+    set count = case
+                  when public.rate_limits.window_start < now() - make_interval(secs => p_window_seconds)
+                  then 1
+                  else public.rate_limits.count + 1
+                end,
+        window_start = case
+                  when public.rate_limits.window_start < now() - make_interval(secs => p_window_seconds)
+                  then now()
+                  else public.rate_limits.window_start
+                end
+  returning count into v_count;
+
+  return v_count <= p_max;
+end;
+$$;
+
+revoke all on function public.rate_limit_hit(text, int, int) from public, anon, authenticated;
+grant execute on function public.rate_limit_hit(text, int, int) to service_role;

--- a/supabase/migrations/20260603000025_refund_atomic.sql
+++ b/supabase/migrations/20260603000025_refund_atomic.sql
@@ -1,0 +1,47 @@
+-- ============================================================================
+-- Resultadismo · Segurança (code review v2) · Reembolso atômico
+-- ----------------------------------------------------------------------------
+-- O reembolso fazia 2 updates soltos (league_payments + leagues) sem serialização.
+-- refund_league trava a liga (for update), re-checa o estado e aplica tudo numa
+-- transação só — idempotente (só refunda quem está 'paid'). Preserva o `raw` do
+-- pagamento (ao contrário de reusar confirm_league_payment). A devolução no
+-- Mercado Pago continua na Edge Function (com X-Idempotency-Key).
+-- ============================================================================
+
+create or replace function public.refund_league(p_league_id uuid)
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_current public.payment_status;
+begin
+  if not public.can_settle_leagues() then
+    raise exception 'Sem permissão para reembolsar.';
+  end if;
+
+  select payment_status into v_current
+  from public.leagues where id = p_league_id
+  for update;
+
+  if v_current is distinct from 'paid' then
+    return false; -- já reembolsada / não paga (idempotente)
+  end if;
+
+  update public.league_payments
+     set status = 'refunded', updated_at = now()
+   where league_id = p_league_id and status = 'paid';
+
+  update public.leagues
+     set payment_status = 'refunded',
+         status = 'archived',
+         deleted_at = coalesce(deleted_at, now())
+   where id = p_league_id;
+
+  return true;
+end;
+$$;
+
+revoke all on function public.refund_league(uuid) from public, anon, authenticated;
+grant execute on function public.refund_league(uuid) to service_role;

--- a/supabase/migrations/20260603000026_predictions_cover_index.sql
+++ b/supabase/migrations/20260603000026_predictions_cover_index.sql
@@ -1,0 +1,12 @@
+-- ============================================================================
+-- Resultadismo · Performance (code review v2) · Índice de cobertura de palpites
+-- ----------------------------------------------------------------------------
+-- H8: get_confronto_ties/standings e usePlayerStats/useAllMyPredictions fazem
+-- lookups por (user_id, match_id) lendo score_type/is_joker. O índice único já
+-- existe em (user_id, match_id), mas sem cobrir essas colunas força heap fetch.
+-- INCLUDE deixa as somas de pontos por período/jogador index-only.
+-- ============================================================================
+
+create index if not exists predictions_user_match_cover_idx
+  on public.predictions (user_id, match_id)
+  include (score_type, is_joker);

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,27 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; font-src 'self' data:; connect-src 'self' https: wss:; frame-ancestors 'none'; base-uri 'self'; object-src 'none'"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Resolve os achados do ultra code review (7 revisores). Tudo validado localmente: **tsc ✅, build ✅, migrations no stack local ✅, smoke Playwright (0 erros de console) ✅**.

## Resolvido
- **Críticos:** C1 RLS de confronto (vazava liga privada p/ anon) · C2 estado terminal do pagamento (reembolso ressuscitava) · C3 CSS injection no escudo · C4 escrita direta em `cup_ties`.
- **Pagamentos (edge):** payer check + amount check + anti-replay + rate limit no webhook; janela de reembolso pelo pagamento (CDC) + RPC atômica; CORS restrito; sem vazar erros upstream.
- **Jogo:** sorteio validado + aleatório; avanço da Copa; bye=vitória; div/0 da cravada; advisory lock do joker; simulate só admin; cupom atômico.
- **Perf:** lazy routes (bundle 792→611KB), índice de palpites, CrestMask memo, filtro `hidden` no servidor, poll com cap.
- **Manutenção/a11y/tooling:** casts obsoletos + tipos regenerados, payments sem `any`, dead exports, erros padronizados, ESLint, CSP, credenciais de dev fora do código, aria/keys.

## ⚠️ Verificar ANTES do merge (merge = deploy em prod)
1. **`payment_mode='live'` em produção** — `simulate_league_payment` agora exige admin; em modo `test` a criação de federação por usuário comum deixaria de simular. Em `live` (esperado), o fluxo usa o checkout real e nada muda.
2. **Origem do app == `APP_URL`** (ou `*.vercel.app`) — o CORS das Edge Functions deixou de ser `*`. Se o domínio de prod não bater com `APP_URL`, as chamadas (checkout/reembolso/sync) seriam bloqueadas.
3. **(Recomendado, não bloqueante)** setar `MP_WEBHOOK_SECRET` em prod p/ validar a assinatura do webhook (os exploits já estão fechados por payer/amount/estado-terminal mesmo sem ele).

## Adiado (com motivo)
- Split dos "god components" (LigaDetailPage/ConfrontoSection/AdminPage) — refactor mecânico sem mudança funcional; melhor numa tarefa isolada p/ não arriscar este deploy.
- Derivar tipos de RPC do confronto de `Functions[...]` e micro-opt de `usePlayerStats` — baixo valor/risco com <200 usuários.
- Timezone unificada (semana BRT) na UI — Low; servidor já usa BRT no joker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)