### PR TITLE
fix(cors): permitir www.resultadismo.com nas Edge Functions

### DIFF
--- a/supabase/functions/_shared/security.ts
+++ b/supabase/functions/_shared/security.ts
@@ -10,6 +10,8 @@ function originAllowed(origin: string): boolean {
   if (!origin) return false;
   const o = origin.replace(/\/+$/, "");
   if (APP_ORIGINS.includes(o)) return true;
+  // domínio de produção (apex + www) — robusto mesmo se APP_URL não estiver setado
+  if (/^https:\/\/(www\.)?resultadismo\.com$/.test(o)) return true;
   // dev local
   if (/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(o)) return true;
   // previews da Vercel


### PR DESCRIPTION
O domínio de prod é www.resultadismo.com; a allow-list de CORS das Edge Functions passa a cobrir apex + www de resultadismo.com, robusto mesmo se APP_URL não estiver setado. Sem isso, checkout/reembolso/sync seriam bloqueados por CORS em produção. Só toca supabase/functions/_shared/security.ts (+2 linhas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)