### PR TITLE
feat(dev): homologação local + DevPanel (só desenvolvimento)

### DIFF
--- a/.claude/07-BUILD-E-DEPLOY.md
+++ b/.claude/07-BUILD-E-DEPLOY.md
@@ -91,7 +91,8 @@ npm run dev          # Vite em http://localhost:5173  (ou 5180 via .claude/launc
 - Portas **5442x** (deslocadas p/ não colidir com outro projeto Supabase na máquina).
 - Após mudar schema local: `npm run db:reset` (re-aplica tudo) e `npm run db:types` (regenera tipos).
 - Usuários de teste no seed (senha `resultadismo123`): `joao.crf93@gmail.com` (admin),
-  `bruno@teste.com`, `luan@teste.com`.
+  `bruno@teste.com` / `luan@teste.com` (membros), `dona@teste.com` (dona de federação, não-admin),
+  `novato@teste.com` (1º acesso, sem federação).
 
 ## 6. Go-live de cobrança (referência — já feito pelo João)
 
@@ -100,3 +101,36 @@ de **produção**, (2) modo **"Mercado Pago"** no admin (senão o app simula), (
 + conta bancária, (4) **chave Pix** cadastrada (p/ Pix aparecer), (5) opcional: webhook no painel MP
 + `MP_WEBHOOK_SECRET`, e (6) um pagamento real de teste ponta a ponta. **Ordem:** token de produção
 primeiro, depois virar o modo (evita janela com modo live + token de teste).
+
+## 7. Homologação local (testar como qualquer usuário, sem tocar produção)
+
+O ambiente de homologação **é o Supabase local** — roda idêntico a produção (mesmas migrations/RLS/
+Edge Functions), mas isolado. Dois **modos de dados**:
+
+1. **Seed (padrão):** dados de teste curados (`supabase/seed.sql`) — rápido, zero risco. Cobre os
+   perfis admin / membro / dono / 1º acesso.
+2. **Snapshot read-only de produção:** `npm run homolog:pull` faz `pg_dump` que **só LÊ** prod (nunca
+   escreve) e carrega a cópia no local. Você vê os **dados reais**; qualquer escrita sua bate no
+   **local**, jamais em prod. Refaça quando quiser dados frescos.
+   ```bash
+   PROD_DB_URL="postgresql://USUARIO:SENHA@HOST:5432/postgres" npm run homolog:pull
+   # ANONYMIZE=1 troca nomes/e-mails (LGPD). URL: Dashboard → Project Settings → Database → Connection string (use o role read-only).
+   ```
+   > ⚠️ Traz **PII real** para a sua máquina — você é o controlador (LGPD). O script só faz `pg_dump`
+   > (leitura) contra prod; toda escrita é no banco LOCAL. Produção **nunca** é tocada.
+
+**DevPanel** (`src/features/dev/DevPanel.tsx`): chip flutuante **só em dev** — gate `import.meta.env.DEV`
+no `AppShell`, então **não entra no bundle de produção** (confirmado: não aparece em `dist/`).
+Arrastável/reposicionável (não tampa nada), recolhível. Alterna **Deslogado / Admin / Membro / Dono /
+1º acesso** e **"entrar como <e-mail>"** (qualquer usuário — essencial no snapshot). Login por senha
+(`VITE_DEV_LOGIN_PASSWORD`, default = senha do seed); o `homolog:pull` seta essa senha em todos os
+usuários locais p/ logar como qualquer um (os reais entram por Google, sem senha — por isso o script
+seta uma).
+
+**Por que não read-replica / staging project:** replica (paga) deixa a **escrita quebrar** (ruim p/
+testar fluxos); staging project é mais infra/custo. Local + snapshot é **grátis**, mais real (você
+escreve à vontade na cópia) e **zero risco a produção**.
+
+**Fluxo:** desenvolve local (seed p/ rapidez, snapshot p/ realismo) → valida (build + navegador) →
+sobe p/ prod por **push na main** (§3). O DevPanel/seed/snapshot são puramente de dev — não afetam o
+app em produção.

--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -22,6 +22,28 @@ _(Nada ainda. Próximas mudanças entram aqui antes de virar uma versão.)_
 
 ---
 
+## [2.2.2] — 2026-06-04
+
+**Ambiente de homologação local + DevPanel.** Tudo **só de desenvolvimento** — gateado por
+`import.meta.env.DEV`; **não entra no bundle de produção** (confirmado: ausente em `dist/`) e não
+muda nada do app em produção.
+
+### Adicionado
+- **DevPanel** (`src/features/dev/DevPanel.tsx`): chip flutuante **arrastável/reposicionável** e
+  recolhível p/ alternar a visualização — **Deslogado / Admin / Membro / Dono / 1º acesso** — e
+  **"entrar como <e-mail>"** (qualquer usuário). Montado no `AppShell` só sob `import.meta.env.DEV`.
+- **Snapshot read-only de produção** (`npm run homolog:pull` → `scripts/homolog-pull-prod.sh`):
+  `pg_dump` que **só lê** prod e carrega a cópia no Supabase local; seta a senha de dev nos usuários
+  locais p/ logar como qualquer um. Opção `ANONYMIZE=1` (LGPD). Produção nunca é tocada.
+- **Seed** ganhou `novato@teste.com` (1º acesso, sem federação) e `dona@teste.com` (dona não-admin,
+  federação "Galera do Trampo").
+
+### Documentação
+- [`07-BUILD-E-DEPLOY.md`](07-BUILD-E-DEPLOY.md) §7 "Homologação local" — arquitetura, como usar e por
+  que local+snapshot em vez de read-replica/staging project.
+
+---
+
 ## [2.2.1] — 2026-06-04
 
 ### Alterado

--- a/.claude/MESTRE.md
+++ b/.claude/MESTRE.md
@@ -14,7 +14,7 @@
 > É a prova de que a IA leu e está obedecendo as regras do `.claude/`. Se a frase **não** aparecer,
 > presuma que estas regras não foram lidas/seguidas.
 
-Versão atual do projeto: **2.2.1** · App em produção: **https://www.resultadismo.com** ·
+Versão atual do projeto: **2.2.2** · App em produção: **https://www.resultadismo.com** ·
 Última revisão desta doc: **2026-06-04**.
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resultadismo",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": true,
   "type": "module",
   "description": "Resultadismo - jogo de palpites de futebol",
@@ -13,7 +13,8 @@
     "db:start": "supabase start",
     "db:stop": "supabase stop",
     "db:reset": "supabase db reset",
-    "db:types": "supabase gen types typescript --local > src/types/database.ts"
+    "db:types": "supabase gen types typescript --local > src/types/database.ts",
+    "homolog:pull": "bash scripts/homolog-pull-prod.sh"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.106.2",

--- a/scripts/homolog-pull-prod.sh
+++ b/scripts/homolog-pull-prod.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Homologação · puxa um SNAPSHOT READ-ONLY de PRODUÇÃO para o Supabase LOCAL.
+# ----------------------------------------------------------------------------
+# pg_dump SÓ LÊ produção — NUNCA escreve. Toda alteração sua acontece na cópia
+# LOCAL; o banco de produção (onde todo mundo joga) jamais é tocado.
+#
+# Uso:
+#   PROD_DB_URL="postgresql://USUARIO:SENHA@HOST:5432/postgres" npm run homolog:pull
+#
+# Pegue a connection string em: Supabase Dashboard → Project Settings → Database
+# → Connection string. Prefira um usuário/role READ-ONLY (mais seguro ainda —
+# garante leitura mesmo se algo der errado). NÃO commite a URL.
+#
+# ⚠️ Os dados de produção contêm dados reais de usuários (nomes, e-mails em
+# auth.users). Eles vão para a sua máquina local. Use com responsabilidade
+# (LGPD — você é o controlador). Para anonimizar, rode com ANONYMIZE=1.
+# ============================================================================
+set -euo pipefail
+
+PROD_DB_URL="${PROD_DB_URL:?Defina PROD_DB_URL com a connection string de PRODUÇÃO (read-only). pg_dump só LÊ prod.}"
+DEV_PW="${HOMOLOG_DEV_PASSWORD:-resultadismo123}"
+ANONYMIZE="${ANONYMIZE:-0}"
+DB="supabase_db_resultadismo"
+DUMP="/tmp/resultadismo-prod-snapshot.sql"
+
+docker ps --format '{{.Names}}' | grep -q "^${DB}$" || {
+  echo "❌ Stack local não está rodando. Rode primeiro:  npm run db:start"; exit 1;
+}
+
+echo "==> 1/4  Dump READ-ONLY de produção (pg_dump só lê)…"
+# Usa o pg_dump do container local como CLIENTE apontando para PROD. --data-only.
+docker exec -e U="$PROD_DB_URL" "$DB" pg_dump "$PROD_DB_URL" \
+  --data-only --no-owner --no-privileges --disable-triggers \
+  --schema=public --schema=auth \
+  --exclude-table-data='auth.schema_migrations' \
+  --exclude-table-data='auth.audit_log_entries' \
+  --exclude-table-data='auth.flow_state' \
+  --exclude-table-data='auth.sessions' \
+  --exclude-table-data='auth.refresh_tokens' \
+  --exclude-table-data='auth.one_time_tokens' \
+  --exclude-table-data='public.rate_limits' \
+  > "$DUMP"
+echo "    snapshot salvo ($(wc -l < "$DUMP" | tr -d ' ') linhas)"
+
+echo "==> 2/4  Reset do banco LOCAL (schema das migrations)…"
+supabase db reset >/dev/null
+
+echo "==> 3/4  Limpa o seed local e carrega o snapshot de produção…"
+docker exec -i "$DB" psql -U postgres -d postgres -q -v ON_ERROR_STOP=1 <<'SQL'
+set session_replication_role = replica;
+truncate
+  public.predictions, public.cup_ties, public.confronto_participants, public.confronto_optins,
+  public.league_competitions, public.league_members, public.leagues, public.league_payments,
+  public.matches, public.teams, public.competitions, public.notifications,
+  public.push_subscriptions, public.discount_codes, public.profiles
+  restart identity cascade;
+delete from auth.identities;
+delete from auth.users;
+SQL
+{ echo "set session_replication_role = replica;"; cat "$DUMP"; } \
+  | docker exec -i "$DB" psql -U postgres -d postgres -q -v ON_ERROR_STOP=1
+
+echo "==> 4/4  Senha de dev em todos os usuários locais (login via DevPanel)…"
+docker exec -i "$DB" psql -U postgres -d postgres -q -v ON_ERROR_STOP=1 <<SQL
+update auth.users
+  set encrypted_password = extensions.crypt('${DEV_PW}', extensions.gen_salt('bf')),
+      email_confirmed_at  = coalesce(email_confirmed_at, now());
+$( [ "$ANONYMIZE" = "1" ] && cat <<'ANON'
+update public.profiles set display_name = 'Jogador ' || left(id::text, 4);
+update auth.users set email = 'user_' || left(id::text, 8) || '@homolog.local';
+update auth.identities set identity_data = jsonb_set(coalesce(identity_data,'{}'), '{email}', to_jsonb('user_' || left(user_id::text,8) || '@homolog.local'));
+ANON
+)
+SQL
+
+rm -f "$DUMP"
+echo ""
+echo "✅ Snapshot de produção carregado no LOCAL. Produção NÃO foi tocada (só leitura)."
+echo "   Abra o app (npm run dev) e use o DevPanel → 'entrar como <e-mail>' p/ ver como qualquer usuário."
+[ "$ANONYMIZE" = "1" ] && echo "   (dados anonimizados: nomes/e-mails substituídos)"

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { lazy, Suspense, type ReactNode } from "react";
 import { Outlet } from "react-router-dom";
 import { BottomNav } from "./BottomNav";
 import { Sidebar } from "./Sidebar";
@@ -7,6 +7,12 @@ import { InstallPrompt } from "@/components/pwa/InstallPrompt";
 import { AccessGate } from "@/features/access/AccessGate";
 import { ConsentBanner } from "@/features/consent/ConsentBanner";
 import { useAuth } from "@/features/auth/AuthProvider";
+
+// DevPanel de homologação — SÓ em dev. Lazy + gate garantem que não entra no
+// bundle de produção (em prod, import.meta.env.DEV é false → nunca importa).
+const DevPanel = import.meta.env.DEV
+  ? lazy(() => import("@/features/dev/DevPanel").then((m) => ({ default: m.DevPanel })))
+  : null;
 
 export function AppShell() {
   const { session, loading } = useAuth();
@@ -47,6 +53,11 @@ export function AppShell() {
     <>
       {content}
       <ConsentBanner />
+      {DevPanel && (
+        <Suspense fallback={null}>
+          <DevPanel />
+        </Suspense>
+      )}
     </>
   );
 }

--- a/src/features/dev/DevPanel.tsx
+++ b/src/features/dev/DevPanel.tsx
@@ -1,0 +1,273 @@
+// ============================================================================
+// DevPanel — chip flutuante de HOMOLOGAÇÃO (SÓ desenvolvimento).
+// ----------------------------------------------------------------------------
+// Permite testar o app como deslogado / admin / membro / dono / 1º acesso, ou
+// "entrar como" qualquer usuário (útil no snapshot de produção). Arrastável e
+// reposicionável (não tampa nada), colapsável, posição persistida.
+//
+// NUNCA vai para produção: o AppShell só renderiza isto sob `import.meta.env.DEV`,
+// então o bundle de prod nem inclui este componente. A senha é a do seed local
+// (já pública em supabase/seed.sql); pode sobrescrever com VITE_DEV_LOGIN_PASSWORD.
+// Login é por senha — funciona com o seed e com o snapshot (o script de snapshot
+// seta esta senha nos usuários locais). → .claude/07-BUILD-E-DEPLOY.md (Homologação).
+// ============================================================================
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { GripVertical, LogOut, Shield, User, Crown, Sparkles, X, FlaskConical } from "lucide-react";
+import { useAuth } from "@/features/auth/AuthProvider";
+import { cn } from "@/lib/utils";
+
+const DEV_PW = import.meta.env.VITE_DEV_LOGIN_PASSWORD ?? "resultadismo123";
+const POS_KEY = "resultadismo-devpanel-pos";
+const OPEN_KEY = "resultadismo-devpanel-open";
+
+type Persona = {
+  id: string;
+  label: string;
+  hint: string;
+  icon: typeof Shield;
+  email?: string;
+  kind: "login" | "logout" | "first";
+};
+
+// Perfis do seed local (ver supabase/seed.sql). No snapshot de prod, "entrar como"
+// cobre qualquer usuário real.
+const PERSONAS: Persona[] = [
+  { id: "out", label: "Deslogado", hint: "visitante / landing", icon: LogOut, kind: "logout" },
+  { id: "admin", label: "Admin", hint: "app-admin", icon: Shield, email: "joao.crf93@gmail.com", kind: "login" },
+  { id: "member", label: "Membro", hint: "não-admin, numa federação", icon: User, email: "bruno@teste.com", kind: "login" },
+  { id: "owner", label: "Dono", hint: "dono de federação (não-admin)", icon: Crown, email: "dona@teste.com", kind: "login" },
+  { id: "first", label: "1º acesso", hint: "usuário novo + onboarding", icon: Sparkles, email: "novato@teste.com", kind: "first" },
+];
+
+/** Limpa os flags de onboarding/coachmarks (mantém a posição/estado do DevPanel). */
+function resetOnboarding() {
+  try {
+    for (const k of Object.keys(localStorage)) {
+      if (k.startsWith("resultadismo") && k !== POS_KEY && k !== OPEN_KEY) localStorage.removeItem(k);
+    }
+  } catch {
+    /* localStorage indisponível */
+  }
+}
+
+function loadPos(): { x: number; y: number } {
+  try {
+    const p = JSON.parse(localStorage.getItem(POS_KEY) ?? "");
+    if (typeof p?.x === "number" && typeof p?.y === "number") return p;
+  } catch {
+    /* sem posição salva */
+  }
+  return { x: 12, y: 80 };
+}
+
+export function DevPanel() {
+  const { user, profile, isAppAdmin, signInWithPassword, signOut } = useAuth();
+  // Por padrão recolhido (só o chip-badge), pra não tampar conteúdo; expande no clique.
+  const [open, setOpen] = useState(() => localStorage.getItem(OPEN_KEY) === "1");
+  const [pos, setPos] = useState(loadPos);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [asEmail, setAsEmail] = useState("");
+  const [err, setErr] = useState<string | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+  const drag = useRef<{ dx: number; dy: number } | null>(null);
+
+  // Mantém dentro da viewport (no mount e ao redimensionar).
+  const clamp = useCallback((x: number, y: number) => {
+    const el = ref.current;
+    const w = el?.offsetWidth ?? 220;
+    const h = el?.offsetHeight ?? 60;
+    return {
+      x: Math.min(Math.max(8, x), Math.max(8, window.innerWidth - w - 8)),
+      y: Math.min(Math.max(8, y), Math.max(8, window.innerHeight - h - 8)),
+    };
+  }, []);
+
+  useEffect(() => {
+    const onResize = () => setPos((p) => clamp(p.x, p.y));
+    onResize();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [clamp, open]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(POS_KEY, JSON.stringify(pos));
+    } catch {
+      /* ignora */
+    }
+  }, [pos]);
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    if (e.button !== 0) return;
+    (e.target as Element).setPointerCapture?.(e.pointerId);
+    drag.current = { dx: e.clientX - pos.x, dy: e.clientY - pos.y };
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!drag.current) return;
+    setPos(clamp(e.clientX - drag.current.dx, e.clientY - drag.current.dy));
+  };
+  const onPointerUp = () => {
+    drag.current = null;
+  };
+
+  const become = async (p: Persona | { kind: "as"; email: string }) => {
+    setErr(null);
+    if (p.kind === "logout") {
+      setBusy("out");
+      resetOnboarding();
+      await signOut().catch(() => {});
+      window.location.assign("/");
+      return;
+    }
+    const email = "email" in p ? p.email : undefined;
+    if (!email) return;
+    setBusy("email" in p && "id" in p ? p.id : "as");
+    if (p.kind === "first") resetOnboarding();
+    await signOut().catch(() => {});
+    const { error } = await signInWithPassword(email, DEV_PW);
+    if (error) {
+      setErr(`${email}: ${error}`);
+      setBusy(null);
+      return;
+    }
+    window.location.assign("/"); // visão limpa como o novo perfil
+  };
+
+  const current = useMemo(() => {
+    if (!user) return { label: "Deslogado", icon: LogOut };
+    if (isAppAdmin) return { label: "Admin", icon: Shield };
+    const match = PERSONAS.find((p) => p.email === user.email);
+    return { label: match?.label ?? profile?.display_name ?? "Logado", icon: match?.icon ?? User };
+  }, [user, isAppAdmin, profile]);
+
+  const setOpenP = (v: boolean) => {
+    setOpen(v);
+    try {
+      localStorage.setItem(OPEN_KEY, v ? "1" : "0");
+    } catch {
+      /* ignora */
+    }
+  };
+
+  const CurIcon = current.icon;
+
+  // Chip colapsado: badge arrastável mostrando o perfil atual.
+  if (!open) {
+    return (
+      <div
+        ref={ref}
+        style={{ left: pos.x, top: pos.y }}
+        className="fixed z-[9999] touch-none select-none"
+      >
+        <button
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onClick={() => !drag.current && setOpenP(true)}
+          title="DevPanel — clique p/ abrir, arraste p/ mover"
+          aria-label="Abrir DevPanel"
+          className="flex cursor-grab items-center gap-1.5 rounded-pill border border-brand-500/40 bg-surface/95 px-2.5 py-1.5 text-xs font-bold text-ink-800 shadow-lg backdrop-blur active:cursor-grabbing"
+        >
+          <FlaskConical className="size-3.5 text-brand-600" />
+          <CurIcon className="size-3.5 text-ink-500" />
+          <span className="max-w-[10ch] truncate">{current.label}</span>
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={ref}
+      style={{ left: pos.x, top: pos.y }}
+      className="fixed z-[9999] w-60 touch-none select-none overflow-hidden rounded-xl border border-brand-500/40 bg-surface/95 shadow-2xl backdrop-blur"
+      role="dialog"
+      aria-label="DevPanel de homologação"
+    >
+      {/* handle / header arrastável */}
+      <div
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        className="flex cursor-grab items-center gap-1.5 border-b border-border bg-brand-600/10 px-2.5 py-1.5 active:cursor-grabbing"
+      >
+        <GripVertical className="size-3.5 text-ink-400" />
+        <FlaskConical className="size-3.5 text-brand-600" />
+        <span className="flex-1 text-xs font-bold uppercase tracking-wide text-ink-700">
+          Homologação
+        </span>
+        <button
+          onClick={() => setOpenP(false)}
+          aria-label="Recolher"
+          className="rounded p-0.5 text-ink-400 hover:bg-ink-100 hover:text-ink-700"
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+
+      <div className="p-2">
+        <p className="mb-1.5 px-1 text-[11px] text-ink-400">
+          Atual: <span className="font-semibold text-ink-700">{current.label}</span>
+          {user?.email && <span className="text-ink-400"> · {user.email}</span>}
+        </p>
+
+        <div className="grid grid-cols-1 gap-1">
+          {PERSONAS.map((p) => {
+            const Icon = p.icon;
+            const active =
+              (p.kind === "logout" && !user) ||
+              (p.email && p.email === user?.email) ||
+              (p.id === "admin" && isAppAdmin && user?.email === p.email);
+            return (
+              <button
+                key={p.id}
+                onClick={() => become(p)}
+                disabled={!!busy}
+                title={p.hint}
+                className={cn(
+                  "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs font-medium transition disabled:opacity-50",
+                  active
+                    ? "bg-brand-600 text-white"
+                    : "bg-ink-100 text-ink-800 hover:bg-ink-200",
+                )}
+              >
+                <Icon className="size-3.5 shrink-0" />
+                <span className="flex-1">{p.label}</span>
+                {busy === p.id && <span className="text-[10px] opacity-70">…</span>}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* entrar como qualquer usuário (snapshot de prod) */}
+        <form
+          className="mt-2 flex gap-1"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (asEmail.trim()) become({ kind: "as", email: asEmail.trim() });
+          }}
+        >
+          <input
+            value={asEmail}
+            onChange={(e) => setAsEmail(e.target.value)}
+            placeholder="entrar como e-mail…"
+            aria-label="Entrar como (e-mail)"
+            className="min-w-0 flex-1 rounded-md border border-ink-200 bg-surface px-2 py-1 text-[11px] outline-none focus:border-brand-500"
+          />
+          <button
+            type="submit"
+            disabled={!!busy || !asEmail.trim()}
+            className="rounded-md bg-ink-800 px-2 py-1 text-[11px] font-semibold text-white disabled:opacity-40"
+          >
+            ir
+          </button>
+        </form>
+
+        {err && <p className="mt-1.5 px-1 text-[10px] leading-tight text-flame-600">{err}</p>}
+        <p className="mt-1.5 px-1 text-[10px] leading-tight text-ink-400">
+          Só local · recarrega ao trocar de perfil.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -41,6 +41,8 @@ declare
   u_joao uuid;
   u_bruno uuid;
   u_luan uuid;
+  u_novato uuid;  -- 1º acesso (sem federação)
+  u_dona uuid;    -- dona de federação (não app-admin)
   c_wc uuid := gen_random_uuid();
   t_bra uuid := gen_random_uuid();
   t_arg uuid := gen_random_uuid();
@@ -59,11 +61,15 @@ declare
   m_g uuid := gen_random_uuid();   -- ao vivo
   lg uuid := gen_random_uuid();
   lc uuid := gen_random_uuid();
+  lg2 uuid := gen_random_uuid();  -- federação da dona
+  lc2 uuid := gen_random_uuid();
 begin
   -- Usuários (o primeiro vira app_admin via trigger handle_new_user)
   u_joao := public.seed_user('joao.crf93@gmail.com', 'João Roque', 'resultadismo123');
   u_bruno := public.seed_user('bruno@teste.com', 'João Bruno', 'resultadismo123');
   u_luan := public.seed_user('luan@teste.com', 'Luan Hatsuo', 'resultadismo123');
+  u_novato := public.seed_user('novato@teste.com', 'Novato da Silva', 'resultadismo123');
+  u_dona := public.seed_user('dona@teste.com', 'Dona Federação', 'resultadismo123');
 
   -- Competição: Copa do Mundo 2026
   insert into public.competitions (id, name, slug, short_name, area, type, provider, provider_code, provider_season, season_start, season_end, status, is_featured)
@@ -108,6 +114,14 @@ begin
   -- liga-competição (modo tabela) para a Copa
   insert into public.league_competitions (id, league_id, competition_id, name, mode)
   values (lc, lg, c_wc, 'Bolão da Copa 2026', 'table');
+
+  -- Federação 2: a DONA é dona (não app-admin) — exercita o perfil "Dono" do DevPanel.
+  insert into public.leagues (id, name, slug, description, owner_id, visibility, join_policy, join_code, status, approved_at, approved_by)
+  values (lg2, 'Galera do Trampo', 'galera-do-trampo', 'Federação criada pela dona (não-admin).', u_dona, 'private', 'invite', 'TRAMPO', 'active', now(), u_joao);
+  insert into public.league_members (league_id, user_id, role, status) values (lg2, u_bruno, 'member', 'active');
+  insert into public.league_competitions (id, league_id, competition_id, name, mode)
+  values (lc2, lg2, c_wc, 'Bolão do Trampo', 'table');
+  -- (novato@teste.com fica SEM federação de propósito → testa o 1º acesso/onboarding)
 
   -- Palpites nos jogos finalizados (cobrem cravada/saldo/acerto/erro)
   insert into public.predictions (user_id, match_id, home_pred, away_pred) values


### PR DESCRIPTION
Ambiente de homologação local pra testar o app como qualquer usuário, **sem nunca tocar produção**. Tudo **só de desenvolvimento** (gate `import.meta.env.DEV`) — confirmado ausente em `dist/`, não muda nada do app em produção.

## O que tem
- **DevPanel** flutuante (arrastável, reposicionável, recolhível): alterna **Deslogado / Admin / Membro / Dono / 1º acesso** e **"entrar como <e-mail>"**. Só em dev.
- **`npm run homolog:pull`**: snapshot **read-only** de produção (`pg_dump` só lê) → carrega no Supabase local + seta senha de dev. `ANONYMIZE=1` p/ LGPD. **Produção nunca é tocada.**
- **Seed**: + `novato@teste.com` (1º acesso) e `dona@teste.com` (dona não-admin).
- **Doc**: 07-BUILD §7 Homologação + CHANGELOG 2.2.2.

## Validação
- ✅ build (tsc+vite) verde · ✅ DevPanel renderiza on-brand (rule #13) · ✅ prod-safe (ausente em `dist/`).
- ⏳ Pendente (Docker estava parado durante a sessão): `npm run db:reset` + login ao vivo no navegador. Como é dev-only, zero risco a produção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)