### PR TITLE
docs(mestre): regra 14 — homologação local + aval do João antes do deploy

### DIFF
--- a/.claude/08-PROCESSO.md
+++ b/.claude/08-PROCESSO.md
@@ -16,7 +16,8 @@
 6. Propagar para TODOS os pontos de contato do site que falam daquilo (coerência)
 7. Atualizar a documentação .claude/ afetada (01–09)
 8. Registrar no CHANGELOG + versionar (+ HISTORICO se decisão/marco)
-9. Subir com segurança (push conforme 09 = deploy em produção)
+9. Homologar com o João: abrir local (npm run dev) + aval explícito antes de subir — sobretudo UI/UX (MESTRE §3 regra 14)
+10. Subir com segurança (push conforme 09 = deploy em produção)
 ```
 
 > **Se a mudança sobe, a coerência do site + a doc + o changelog sobem junto.** Mudar comportamento
@@ -78,6 +79,10 @@ coisa — **nunca** um ponto novo e outro velho.
   [`HISTORICO.md`](HISTORICO.md).
 
 ## 7. Subir (push = deploy em produção)
+
+> **Gate (MESTRE §3 regra 14):** antes de qualquer push/merge na `main`, **abra a mudança rodando
+> localmente** (`npm run dev`; com dados reais via `npm run homolog:pull` quando ajudar) e **espere o
+> aval explícito do João** — sobretudo em **UI/UX**, que ele precisa ver no navegador. Sem OK, não sobe.
 
 1. `git fetch` de novo; rebase/merge de `origin/main` se andou (→ [`09`](09-PARALELISMO.md)).
 2. **Stage explícito por arquivo** (nunca `git add -A`). Conferir `git diff --cached --name-only` —

--- a/.claude/MESTRE.md
+++ b/.claude/MESTRE.md
@@ -110,6 +110,13 @@ de docs + changelog (seção 5). Cada uma tem dono num doc específico.
    falar do jogo, entende **rápido** o que fazer e o que está acontecendo; o que estiver complexo,
    simplifique (sem infantilizar). Vale para **design e texto**. → [`10`](10-UX-WRITING.md) (texto),
    [`02`](02-CODIGO.md) §4, [`DESIGN.md`](../DESIGN.md).
+14. **Homologação local antes do deploy (checagem do João).** Toda mudança passa **primeiro** pela
+   checagem do João em **homologação local**. Antes de `git push`/merge na `main` (que dispara o
+   deploy em produção), a IA **abre a mudança rodando localmente** (`npm run dev` — idealmente com o
+   snapshot real via `npm run homolog:pull`) e **espera o aval explícito do João**; **sobretudo em
+   qualquer alteração de UI/UX**, que ele precisa **ver no navegador** antes de subir. Sem o OK do
+   João, **não há push/merge na `main`**. → §5 passo 9, [`07`](07-BUILD-E-DEPLOY.md),
+   [`08`](08-PROCESSO.md).
 
 ---
 
@@ -173,7 +180,13 @@ de docs + changelog (seção 5). Cada uma tem dono num doc específico.
    versão** (ver seção 6) + `package.json`. Decisão de mudar uma regra ou marco grande → **também**
    uma nota em [`HISTORICO.md`](HISTORICO.md).
 
-**9. Subir com segurança.** Só então: push (conforme doc 09 — fast-forward sobre `origin/main`,
+**9. Homologar com o João (gate antes do deploy).** Antes de subir, **abra a mudança rodando
+   localmente** (`npm run dev`; quando fizer sentido, com dados reais via `npm run homolog:pull`) e
+   **espere o aval explícito do João** — **sobretudo em qualquer alteração de UI/UX**, que ele
+   precisa **ver no navegador**. Sem o OK do João, **não** se faz push/merge na `main`. (regra
+   central 14)
+
+**10. Subir com segurança.** Só então: push (conforme doc 09 — fast-forward sobre `origin/main`,
    só os **seus** arquivos). Push na `main` = **deploy em produção**: confirme os checks verdes
    (Supabase Preview, Vercel, Deploy Edge Functions).
 


### PR DESCRIPTION
A pedido do João: codifica a **checagem em homologação antes do deploy** como regra central.

- **MESTRE §3 — regra 14:** toda mudança passa primeiro pela checagem do João em homologação local; antes de push/merge na `main` (= deploy em prod), abrir rodando localmente (`npm run dev`, com `npm run homolog:pull` quando ajudar) e esperar o **aval explícito** — **sobretudo UI/UX**, que ele vê no navegador.
- **MESTRE §5 — passo 9** (gate) + "Subir" renumerado p/ 10.
- **08-PROCESSO** — resumo da ordem (§1) + gate na seção "Subir" (§7).
- **CHANGELOG** [Não lançado] › Processo.

Docs-only (não afeta o app). Stage explícito; sem `git add -A`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)