### PR TITLE
feat(home): primeira dobra deslogado, scroll cue, grade desktop e microinterações

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -18,7 +18,19 @@ Tipos de entrada: **Adicionado**, **Alterado**, **Corrigido**, **Removido**, **S
 
 ## [Não lançado]
 
-_Nada pendente._
+### Adicionado
+- **Home pública (deslogado) — primeira dobra + convite de rolagem.** Num dia cheio, os jogos
+  aparecem só até a altura do viewport (cortando onde estiver, com fade) e um convite "Conheça o
+  Resultadismo" fixo na base leva às seções de venda — teaser em vez de despejar a lista toda
+  (`src/features/landing/FirstFold.tsx` + `ScrollCue.tsx`).
+
+### Alterado
+- **Home no desktop usa a largura toda** (container igual ao header), com **jogos em 2 colunas** e as
+  seções de venda (o que dá pra fazer / pontuação / competições) em colunas — aproveita o espaço
+  lateral e encurta a página.
+- **Microinterações/animações sutis na landing** (IntersectionObserver + CSS `ease-out-expo`):
+  reveals com _stagger_, _hover lift_ e deriva no convite de rolagem. Sem bounce; respeita
+  `prefers-reduced-motion` (DESIGN.md). Sem dependência nova (sem GSAP).
 
 ---
 

--- a/src/features/landing/FirstFold.tsx
+++ b/src/features/landing/FirstFold.tsx
@@ -1,0 +1,64 @@
+import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { ScrollCue } from "./ScrollCue";
+
+const prefersReduced = () =>
+  typeof window !== "undefined" &&
+  !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
+/**
+ * Primeira dobra da home pública (só visitantes deslogados): mostra os jogos
+ * apenas até a altura do viewport — cortando onde estiver — com um fade no fim
+ * e um convite de rolagem fixo na base. Clicar (ou rolar) revela as seções de
+ * "venda" abaixo. A ideia é teaser: o visitante vê que tem jogo e é convidado a
+ * descer, sem despejar a lista inteira num dia cheio.
+ */
+export function FirstFold({
+  children,
+  scrollTargetId,
+}: {
+  children: ReactNode;
+  scrollTargetId: string;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [height, setHeight] = useState<number>();
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const compute = () => {
+      // distância do topo do bloco até o documento; com a página no topo isso é
+      // o quanto sobra até o fim do viewport. Cap mínimo pra telas baixinhas.
+      const docTop = el.getBoundingClientRect().top + window.scrollY;
+      setHeight(Math.max(280, Math.round(window.innerHeight - docTop - 8)));
+    };
+    compute();
+    window.addEventListener("resize", compute);
+    // recalcula depois que fontes/layout assentam (evita corte no lugar errado)
+    const t = window.setTimeout(compute, 250);
+    return () => {
+      window.removeEventListener("resize", compute);
+      window.clearTimeout(t);
+    };
+  }, []);
+
+  const goMore = () => {
+    const target = document.getElementById(scrollTargetId);
+    const behavior: ScrollBehavior = prefersReduced() ? "auto" : "smooth";
+    if (target) target.scrollIntoView({ behavior, block: "start" });
+    else window.scrollTo({ top: window.innerHeight, behavior });
+  };
+
+  return (
+    <div ref={ref} className="relative overflow-hidden" style={height ? { height } : undefined}>
+      {children}
+
+      {/* fade do corte + convite, fixos na base da dobra */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex flex-col items-center">
+        <div className="h-28 w-full bg-gradient-to-t from-background via-background/85 to-transparent" />
+        <div className="pointer-events-auto flex w-full justify-center bg-background pb-2">
+          <ScrollCue onClick={goMore} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/landing/LandingSections.tsx
+++ b/src/features/landing/LandingSections.tsx
@@ -6,7 +6,6 @@ import {
   Trophy,
   Sparkles,
   Gift,
-  ChevronDown,
   ArrowRight,
   type LucideIcon,
 } from "lucide-react";
@@ -50,7 +49,7 @@ function Reveal({
     <div
       ref={ref}
       className={cn(
-        "translate-y-3 opacity-0 transition-all duration-500 [transition-timing-function:var(--ease-out-quart)] [&.is-visible]:translate-y-0 [&.is-visible]:opacity-100",
+        "translate-y-5 opacity-0 transition-all duration-[600ms] [transition-timing-function:var(--ease-out-expo)] will-change-transform [&.is-visible]:translate-y-0 [&.is-visible]:opacity-100",
         className,
       )}
       style={delay ? { transitionDelay: `${delay}ms` } : undefined}
@@ -85,7 +84,7 @@ function FeatureRow({
   children: ReactNode;
 }) {
   return (
-    <div className="flex gap-3.5 rounded-lg bg-surface p-4 shadow-[var(--shadow-soft)] ring-1 ring-border">
+    <div className="flex h-full gap-3.5 rounded-lg bg-surface p-4 shadow-[var(--shadow-soft)] ring-1 ring-border transition-all duration-200 [transition-timing-function:var(--ease-out-quart)] hover:-translate-y-0.5 hover:shadow-[var(--shadow-pop)] hover:ring-brand-200">
       <span className="grid size-11 shrink-0 place-items-center rounded-md bg-brand-500/10 text-brand-600">
         <Icon className="size-5.5" strokeWidth={2.2} />
       </span>
@@ -129,7 +128,7 @@ function ScoreRow({
   }[tone];
 
   return (
-    <div className="rounded-lg bg-surface p-3.5 shadow-[var(--shadow-soft)] ring-1 ring-border">
+    <div className="flex h-full flex-col rounded-lg bg-surface p-3.5 shadow-[var(--shadow-soft)] ring-1 ring-border transition-all duration-200 [transition-timing-function:var(--ease-out-quart)] hover:-translate-y-0.5 hover:shadow-[var(--shadow-pop)] hover:ring-brand-200">
       <div className="flex items-center gap-3">
         <span
           className={cn(
@@ -174,9 +173,9 @@ function CompetitionPill({
   return (
     <div
       className={cn(
-        "flex items-center justify-between gap-2 rounded-pill border px-4 py-2.5 text-sm font-semibold",
+        "flex items-center justify-between gap-2 rounded-pill border px-4 py-2.5 text-sm font-semibold transition-all duration-200 [transition-timing-function:var(--ease-out-quart)] hover:-translate-y-0.5",
         live
-          ? "border-brand-300 bg-brand-500/10 text-brand-800"
+          ? "border-brand-300 bg-brand-500/10 text-brand-800 hover:shadow-[var(--shadow-soft)]"
           : "border-dashed border-ink-200 bg-surface text-ink-400",
       )}
     >
@@ -203,15 +202,7 @@ function CompetitionPill({
  */
 export function LandingSections({ onOpenLogin }: { onOpenLogin: () => void }) {
   return (
-    <div className="mt-10 space-y-16 pb-4">
-      {/* divisor sutil entre os jogos e a parte de venda */}
-      <div className="flex flex-col items-center gap-1 text-ink-300">
-        <span className="text-xs font-semibold uppercase tracking-[0.18em]">
-          Conheça o Resultadismo
-        </span>
-        <ChevronDown className="size-4 animate-bounce [animation-duration:2s]" />
-      </div>
-
+    <div id="conheca-resultadismo" className="scroll-mt-6 space-y-16 pb-4 pt-6">
       {/* ---- HERO ---- */}
       <section>
         <Reveal className="rounded-xl bg-brand-600 px-6 py-9 text-center shadow-[var(--shadow-brand)] sm:px-8 sm:py-12">
@@ -241,7 +232,7 @@ export function LandingSections({ onOpenLogin }: { onOpenLogin: () => void }) {
       {/* ---- O QUE VOCÊ PODE FAZER ---- */}
       <section>
         <SectionTitle kicker="O jogo" title="O que você pode fazer" />
-        <div className="space-y-3">
+        <div className="grid gap-3 lg:grid-cols-3">
           <Reveal>
             <FeatureRow icon={Target} title="Palpitar nos jogos">
               Para cada jogo, você dá um palpite de placar, tipo 2×1. Quanto mais perto do resultado
@@ -265,8 +256,8 @@ export function LandingSections({ onOpenLogin }: { onOpenLogin: () => void }) {
       {/* ---- PONTUAÇÃO ---- */}
       <section>
         <SectionTitle kicker="Como pontua" title="Acertou, pontuou" />
-        <Reveal>
-          <div className="space-y-2.5">
+        <div className="grid gap-2.5 lg:grid-cols-3">
+          <Reveal>
             <ScoreRow
               tone="gold"
               pts={3}
@@ -275,6 +266,8 @@ export function LandingSections({ onOpenLogin }: { onOpenLogin: () => void }) {
               palpite="2×1"
               resultado="2×1"
             />
+          </Reveal>
+          <Reveal delay={70}>
             <ScoreRow
               tone="grass"
               pts={2}
@@ -283,6 +276,8 @@ export function LandingSections({ onOpenLogin }: { onOpenLogin: () => void }) {
               palpite="1×1"
               resultado="2×2"
             />
+          </Reveal>
+          <Reveal delay={140}>
             <ScoreRow
               tone="aqua"
               pts={1}
@@ -291,18 +286,18 @@ export function LandingSections({ onOpenLogin }: { onOpenLogin: () => void }) {
               palpite="2×0"
               resultado="1×0"
             />
-          </div>
-          <p className="mt-3 text-center text-xs text-ink-400">
-            Quanto mais perto do resultado real, mais ponto você leva.
-          </p>
-        </Reveal>
+          </Reveal>
+        </div>
+        <p className="mt-3 text-center text-xs text-ink-400">
+          Quanto mais perto do resultado real, mais ponto você leva.
+        </p>
       </section>
 
       {/* ---- COMPETIÇÕES ---- */}
       <section>
         <SectionTitle kicker="Onde jogar" title="As competições" />
         <Reveal>
-          <div className="space-y-2.5">
+          <div className="grid gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
             <CompetitionPill name="Copa do Mundo 2026" status="ativa" />
             <CompetitionPill name="Brasileirão" status="em breve" />
             <CompetitionPill name="Libertadores" status="em breve" />

--- a/src/features/landing/ScrollCue.tsx
+++ b/src/features/landing/ScrollCue.tsx
@@ -1,0 +1,33 @@
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Convite de rolagem da home pública. Sutil (deriva, sem bounce — DESIGN.md),
+ * clicável e acessível: leva o visitante às seções de "venda" abaixo da dobra.
+ */
+export function ScrollCue({
+  label = "Conheça o Resultadismo",
+  onClick,
+  className,
+}: {
+  label?: string;
+  onClick?: () => void;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`${label} — rolar para ver mais`}
+      className={cn(
+        "group flex flex-col items-center gap-1.5 rounded-pill px-4 py-1.5 text-ink-400 transition-colors hover:text-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50",
+        className,
+      )}
+    >
+      <span className="text-[11px] font-semibold uppercase tracking-[0.18em]">{label}</span>
+      <span className="grid size-9 place-items-center rounded-full bg-surface text-brand-600 shadow-[var(--shadow-soft)] ring-1 ring-border transition-all duration-200 [transition-timing-function:var(--ease-out-quart)] group-hover:-translate-y-0.5 group-hover:shadow-[var(--shadow-pop)] group-hover:ring-brand-300">
+        <ChevronDown className="size-4 animate-scroll-cue" strokeWidth={2.5} />
+      </span>
+    </button>
+  );
+}

--- a/src/features/matches/JogosPage.tsx
+++ b/src/features/matches/JogosPage.tsx
@@ -20,6 +20,7 @@ import {
 } from "./api";
 import { useLoginModal } from "@/features/auth/LoginModalProvider";
 import { LandingSections } from "@/features/landing/LandingSections";
+import { FirstFold } from "@/features/landing/FirstFold";
 
 const ALL = "all" as const;
 type Scope = typeof ALL | string;
@@ -145,8 +146,28 @@ export function JogosPage() {
 
   const hasComps = (competitions?.length ?? 0) > 0;
 
+  // Grade de jogos: 1 coluna no mobile, 2 no desktop pra aproveitar a largura.
+  const gamesGrid = (
+    <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+      {dayMatches.map((m) => {
+        const compKey = m.competition_id ?? "?";
+        const wk = weekKey(m.kickoff_at);
+        return (
+          <MatchCard
+            key={m.id}
+            match={m}
+            prediction={predMap?.get(m.id) ?? null}
+            jokersUsed={jokersByCompWeek.get(`${compKey}:${wk}`) ?? 0}
+            maxJokers={jokerMax.get(compKey) ?? 2}
+          />
+        );
+      })}
+    </div>
+  );
+
   return (
     <Page
+      wide
       title={session ? "Jogos" : undefined}
       action={
         totalPoints > 0 ? (
@@ -260,7 +281,7 @@ export function JogosPage() {
       )}
 
       {loadingMatches ? (
-        <div className="space-y-3">
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} className="h-28 w-full" />
           ))}
@@ -275,22 +296,10 @@ export function JogosPage() {
               : "Quando houver jogos nesta competição, eles aparecem aqui por dia."
           }
         />
+      ) : !session ? (
+        <FirstFold scrollTargetId="conheca-resultadismo">{gamesGrid}</FirstFold>
       ) : (
-        <div className="space-y-3">
-          {dayMatches.map((m) => {
-            const compKey = m.competition_id ?? "?";
-            const wk = weekKey(m.kickoff_at);
-            return (
-              <MatchCard
-                key={m.id}
-                match={m}
-                prediction={predMap?.get(m.id) ?? null}
-                jokersUsed={jokersByCompWeek.get(`${compKey}:${wk}`) ?? 0}
-                maxJokers={jokerMax.get(compKey) ?? 2}
-              />
-            );
-          })}
-        </div>
+        gamesGrid
       )}
 
       {/* Landing híbrida para visitantes deslogados. */}

--- a/src/index.css
+++ b/src/index.css
@@ -227,6 +227,13 @@
 }
 .animate-coachmark-pulse { animation: coachmark-pulse 1.8s var(--ease-out-quart) infinite; }
 
+/* Convite de rolagem da home pública — deriva suave (sem bounce, ease-out) */
+@keyframes scroll-cue {
+  0%, 100% { transform: translateY(0); opacity: 0.75; }
+  50% { transform: translateY(4px); opacity: 1; }
+}
+.animate-scroll-cue { animation: scroll-cue 1.9s var(--ease-out-quart) infinite; }
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.01ms !important;


### PR DESCRIPTION
Redesign da home pública (homologado localmente com o João — regra 14; OK explícito pra subir).

## O que muda
- **Deslogado:** jogos só na **primeira dobra** (altura do viewport, corta onde estiver) com fade + **convite de rolagem** fixo na base que leva às seções de venda. Teaser, em vez de despejar a lista num dia cheio (`FirstFold` + `ScrollCue`).
- **Desktop:** container **largo igual ao header** + **jogos em 2 colunas** + seções de venda em colunas — aproveita a largura e encurta a página.
- **Microinterações/animações** nativas (IntersectionObserver + CSS `ease-out-expo`): reveals com _stagger_, _hover lift_, deriva no convite. Sem bounce, respeita `prefers-reduced-motion` (DESIGN.md). **Sem GSAP** (sem dependência nova).

## Paralelismo
- **`MatchCard.tsx` ficou de fora de propósito:** outro chat está editando esse arquivo (`feat(jogos): ao vivo automático`). O hover de card (polish de 1 linha) fica pra depois pra não colidir. Esta mudança toca só `JogosPage`, `landing/*` e `index.css` — zero sobreposição com o trabalho paralelo.
- CHANGELOG em `[Não lançado]` (sem cortar versão, pra não colidir com os bumps dos outros chats).

## Validação
✅ build de produção verde · ✅ navegador (mobile fold + desktop 2-col + seções 3-col + clique do cue rola).

🤖 Generated with [Claude Code](https://claude.com/claude-code)