### PR TITLE
fix(landing): não cortar o anel dos cards ao vivo na primeira dobra (regressão 2.7.0)

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -18,6 +18,12 @@ Tipos de entrada: **Adicionado**, **Alterado**, **Corrigido**, **Removido**, **S
 
 ## [Não lançado]
 
+### Corrigido
+- **Card ao vivo na primeira dobra não tem mais a borda cortada.** O teto de 2 linhas do teaser
+  deslogado (2.7.0) passou a limitar a **quantidade** de cards renderizados, em vez de
+  `overflow-hidden` — que clipava o anel (`ring`) dos jogos AO VIVO. Mesma regra (máx 2 linhas, sem
+  espaço vazio), agora sem corte. (`FirstFold` + `JogosPage`)
+
 ---
 
 ## [2.7.0] — 2026-06-05

--- a/src/features/landing/FirstFold.tsx
+++ b/src/features/landing/FirstFold.tsx
@@ -1,23 +1,17 @@
-import { useCallback, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { ScrollCue } from "./ScrollCue";
 
 const prefersReduced = () =>
   typeof window !== "undefined" &&
   !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
 
-/** Teaser deslogado: no máximo 2 linhas de jogos. */
-const MAX_ROWS = 2;
-
 /**
  * Primeira dobra da home pública (só visitantes deslogados).
  *
- * Mostra **no máximo 2 linhas de jogos** (4 no desktop, 2 no mobile) e o convite
- * de rolagem cola **logo abaixo** dos jogos visíveis — sem espaço vazio:
- *  - 1–2 linhas de jogos → a dobra tem o tamanho exato dos jogos;
- *  - mais que isso → corta na 2ª linha (as demais ficam pra quem entra) e o
- *    convite segue logo abaixo.
- *
- * Teaser: o visitante vê que tem jogo e é convidado a descer pras seções.
+ * Renderiza o teaser de jogos (a quantidade já vem limitada a no máximo 2 linhas
+ * pelo JogosPage — 4 no desktop, 2 no mobile) e cola o convite de rolagem logo
+ * abaixo dos jogos. Sem `overflow:hidden`/clip, pra não cortar o anel (ring) dos
+ * cards ao vivo. Clicar leva às seções de "venda" abaixo.
  */
 export function FirstFold({
   children,
@@ -26,40 +20,6 @@ export function FirstFold({
   children: ReactNode;
   scrollTargetId: string;
 }) {
-  const contentRef = useRef<HTMLDivElement>(null);
-  const [maxH, setMaxH] = useState<number>();
-
-  const measure = useCallback(() => {
-    const grid = contentRef.current?.firstElementChild as HTMLElement | null;
-    if (!grid) return;
-    const cards = Array.from(grid.children) as HTMLElement[];
-    // nº de colunas atual (responsivo) lido direto do CSS grid
-    const cols =
-      getComputedStyle(grid).gridTemplateColumns.split(" ").filter(Boolean).length || 1;
-    const limit = cols * MAX_ROWS;
-    if (cards.length > limit) {
-      // teto = base da última carta da 2ª linha (corta a 3ª linha em diante)
-      const top = grid.getBoundingClientRect().top;
-      const lastVisible = cards[limit - 1]!;
-      setMaxH(Math.round(lastVisible.getBoundingClientRect().bottom - top));
-    } else {
-      setMaxH(undefined); // cabe em ≤2 linhas → sem corte, encolhe pro conteúdo
-    }
-  }, []);
-
-  useLayoutEffect(() => {
-    measure();
-    window.addEventListener("resize", measure);
-    const t = window.setTimeout(measure, 250); // fontes/layout assentam
-    const ro = new ResizeObserver(measure); // jogos carregam async / quebra de coluna
-    if (contentRef.current) ro.observe(contentRef.current);
-    return () => {
-      window.removeEventListener("resize", measure);
-      window.clearTimeout(t);
-      ro.disconnect();
-    };
-  }, [measure]);
-
   const goMore = () => {
     const target = document.getElementById(scrollTargetId);
     const behavior: ScrollBehavior = prefersReduced() ? "auto" : "smooth";
@@ -67,19 +27,9 @@ export function FirstFold({
     else window.scrollTo({ top: window.innerHeight, behavior });
   };
 
-  const clamped = maxH != null;
-
   return (
     <div>
-      <div
-        ref={contentRef}
-        className={clamped ? "overflow-hidden" : undefined}
-        style={clamped ? { maxHeight: maxH } : undefined}
-      >
-        {children}
-      </div>
-
-      {/* convite cola logo abaixo dos jogos visíveis (sem espaço vazio) */}
+      {children}
       <div className="mt-5 flex justify-center">
         <ScrollCue onClick={goMore} />
       </div>

--- a/src/features/matches/JogosPage.tsx
+++ b/src/features/matches/JogosPage.tsx
@@ -147,9 +147,17 @@ export function JogosPage() {
   const hasComps = (competitions?.length ?? 0) > 0;
 
   // Grade de jogos: 1 coluna no mobile, 2 no desktop pra aproveitar a largura.
+  // Teaser deslogado: no máximo 2 linhas (4 no desktop, 2 no mobile). Limita o que
+  // renderiza — sem overflow/clip, pra não cortar o anel (ring) dos cards ao vivo.
+  const foldGames = session ? dayMatches : dayMatches.slice(0, 4);
   const gamesGrid = (
-    <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-      {dayMatches.map((m) => {
+    <div
+      className={cn(
+        "grid grid-cols-1 gap-3 lg:grid-cols-2",
+        !session && "max-lg:[&>*:nth-child(n+3)]:hidden", // mobile: só 2 (2 linhas)
+      )}
+    >
+      {foldGames.map((m) => {
         const compKey = m.competition_id ?? "?";
         const wk = weekKey(m.kickoff_at);
         return (


### PR DESCRIPTION
**Hotfix de regressão ao vivo.** O teto de 2 linhas (2.7.0) usava `overflow-hidden`, que clipava o anel (`ring-2`) dos cards **AO VIVO** (o anel desenha pra fora da borda). Ficava com a borda cortada e estranho.

Nova abordagem, **sem clip**: `JogosPage` limita o teaser deslogado a 4 jogos (slice) e esconde o 3º/4º no mobile via CSS (`nth-child`); `FirstFold` deixa de usar overflow/max-height. Mesma regra (no máx 2 linhas, seta colada, sem espaço vazio), agora **sem cortar o anel**.

Toca só `FirstFold.tsx` + `JogosPage.tsx` (+ CHANGELOG). Validado: typecheck + build + navegador (cards ao vivo com anel inteiro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)