### PR TITLE
chore(design-sync): entradas do ResultaDS para o claude.ai/design

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,72 @@
+# Design-sync — notas do repo (Resultadismo → claude.ai/design)
+
+Este repo é um **app** (Vite + React 19 SPA), não uma biblioteca. O DS vive em
+`src/components/ui/*` + `ScorePill`, com Tailwind v4 e tokens OKLCH em `src/index.css`.
+Shape = **package**, modo **synth-entry** via barrel. 22 componentes sincronizados.
+
+## Como este build funciona (peças não óbvias)
+
+- **Barrel `--entry`**: `.design-sync/entry.ts` reexporta os componentes. É passado como
+  `--entry` porque o conversor deriva o `PKG_DIR` subindo do entry até o `package.json` com
+  nome — sem `--entry`, ele procuraria `node_modules/resultadismo` (inexistente num app) e
+  quebra. Comando:
+  ```
+  node .ds-sync/package-build.mjs --config .design-sync/config.json \
+    --node-modules ./node_modules --entry .design-sync/entry.ts --out ./ds-bundle
+  ```
+- **CSS = Tailwind compilado**: `cfg.cssEntry` aponta para `.design-sync/compiled-tailwind.css`,
+  que é uma CÓPIA de `dist/assets/index-*.css` (a hash muda a cada build). **No re-sync:
+  rode `npm run build` e depois `cp dist/assets/index-*.css .design-sync/compiled-tailwind.css`
+  ANTES do conversor.** O source `src/index.css` (com `@import "tailwindcss"` + `@theme`) NÃO
+  serve — o esbuild não compila Tailwind.
+- **tsconfig dedicado** `.design-sync/tsconfig.paths.json` (não o `tsconfig.app.json`): os globs
+  `include`/`exclude` com `/**/_*` do app quebram o comment-stripper do `tsconfigPathsPlugin`
+  (lê `/* … */` como comentário e apaga `paths`). O dedicado só tem o alias `@/`.
+- **Shim de crest**: `src/lib/crest.ts` usa `import.meta.glob` (macro só do Vite) no topo →
+  vira `undefined` no esbuild e **mata o bundle inteiro** (TypeError na carga do IIFE). O
+  alias `@/lib/crest` é redirecionado (no tsconfig.paths.json) para `.design-sync/shims/crest.ts`,
+  gerado por `node .design-sync/shims/gen-crest-shim.mjs` (troca os globs por imports estáticos
+  dos 20 SVGs em `src/assets/{escudos,grupos}`; esbuild inlina como data-URL). **Regenere o shim
+  se os SVGs mudarem.**
+- **Overlays** (Modal, ConfirmDialog): os previews envolvem o componente num wrapper com
+  `transform: translateZ(0)` — isso torna o wrapper o bloco de contenção do `position:fixed`,
+  então overlay + diálogo renderizam DENTRO do card (senão o topo do diálogo escapa do frame).
+  `cfg.overrides` fixa `cardMode:single` + viewport largo (≥640 → layout centralizado do `sm:`).
+
+## Previews só usam classes já existentes no app
+
+O Tailwind v4 do app **NÃO escaneia** `.design-sync/previews/` — classes só-de-preview não
+entram no CSS compilado. Por isso os previews usam **inline-style para layout** e só classes
+que o app já usa (ex.: `Skeleton` é dimensionado por wrapper inline + `h-full w-full`, não por
+`w-3/5`). Se precisar de classe nova num preview, ou use inline-style, ou adicione a fonte ao
+Tailwind (`@source`) — mas isso mexe em `src/index.css` (app, exige OK do PO).
+
+## Fontes
+
+Marca = **Ubuntu** self-hosted (`public/fonts/ubuntu-latin-*.woff2`), NÃO Inter (o `DESIGN.md`
+está desatualizado nesse ponto — diz "Inter"). `cfg.extraFonts` copia os 6 woff2; o `@font-face`
+já vem no CSS compilado e as urls são reescritas para `fonts/`.
+
+## Upload (pendente)
+
+Este ambiente **não tem login interativo** (`/design-login` indisponível), então o upload para o
+claude.ai/design NÃO foi feito. O `ds-bundle/` está pronto e validado. Para subir: rodar
+`/design-sync` num terminal `claude` interativo (cria o projeto + envia), ou usar a própria
+ferramenta com o `ds-bundle/`. Nenhum `projectId` foi gravado ainda (nada foi criado).
+
+## Riscos de re-sync (watch-list)
+
+- `compiled-tailwind.css` é gitignored e regenerado do `dist` — a hash muda; sempre recopie.
+- O shim de crest e o barrel são espelhos manuais do app: se `src/lib/crest.ts` mudar de API,
+  ou surgirem/sumirem componentes em `src/components/ui/`, atualize `entry.ts`, o
+  `componentSrcMap` e regenere o shim.
+- Previews de estados interativos (Select/Combobox abertos, hover) são mostrados FECHADOS de
+  propósito (não renderizam estáticos). ToastProvider dispara toasts na montagem (timing do
+  capture).
+- Cores/formas de crest nos previews usam chaves válidas de `AVATAR_COLORS`
+  (turquesa, verde, azul, dourado, laranja, vermelho, roxo, grafite, gelo) e shapes
+  escudo `padrao/1..16`, flâmula `1..3`. Se a paleta/pasta mudar, revise os previews.
+
+## Known render warns
+
+- Nenhum warn pendente no último validate (22/22 renderizam limpo).

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,47 @@
+{
+  "pkg": "resultadismo",
+  "globalName": "ResultaDS",
+  "shape": "package",
+  "buildCmd": "npm run build",
+  "readmeHeader": ".design-sync/conventions.md",
+  "srcDir": "src",
+  "tsconfig": ".design-sync/tsconfig.paths.json",
+  "cssEntry": ".design-sync/compiled-tailwind.css",
+  "componentSrcMap": {
+    "Avatar": "src/components/ui/Avatar.tsx",
+    "Badge": "src/components/ui/Badge.tsx",
+    "Button": "src/components/ui/Button.tsx",
+    "Card": "src/components/ui/Card.tsx",
+    "Coachmark": "src/components/ui/Coachmark.tsx",
+    "Combobox": "src/components/ui/Combobox.tsx",
+    "ConfirmDialog": "src/components/ui/ConfirmDialog.tsx",
+    "CrestEditor": "src/components/ui/CrestEditor.tsx",
+    "CrestMask": "src/components/ui/CrestMask.tsx",
+    "EmptyState": "src/components/ui/EmptyState.tsx",
+    "Escudo": "src/components/ui/Escudo.tsx",
+    "Input": "src/components/ui/Input.tsx",
+    "Modal": "src/components/ui/Modal.tsx",
+    "ScrollRow": "src/components/ui/ScrollRow.tsx",
+    "SegmentedControl": "src/components/ui/SegmentedControl.tsx",
+    "Select": "src/components/ui/Select.tsx",
+    "Skeleton": "src/components/ui/Skeleton.tsx",
+    "SortControl": "src/components/ui/SortControl.tsx",
+    "Spinner": "src/components/ui/Spinner.tsx",
+    "Switch": "src/components/ui/Switch.tsx",
+    "ToastProvider": "src/components/ui/Toast.tsx",
+    "ScorePill": "src/components/ScorePill.tsx"
+  },
+  "overrides": {
+    "Modal": { "cardMode": "single", "viewport": "700x360" },
+    "ConfirmDialog": { "cardMode": "single", "viewport": "700x380", "primaryStory": "Destrutivo" },
+    "ToastProvider": { "cardMode": "single", "viewport": "480x400" }
+  },
+  "extraFonts": [
+    "public/fonts/ubuntu-latin-300.woff2",
+    "public/fonts/ubuntu-latin-400.woff2",
+    "public/fonts/ubuntu-latin-400italic.woff2",
+    "public/fonts/ubuntu-latin-500.woff2",
+    "public/fonts/ubuntu-latin-500italic.woff2",
+    "public/fonts/ubuntu-latin-700.woff2"
+  ]
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,73 @@
+# ResultaDS — como construir com este design system
+
+App de **bolão de futebol** (Resultadismo): palpitar o placar final e pontuar. Estética
+**calorosa e objetiva** (turquesa de marca), mobile-first, clara por padrão + dark completo.
+Prioridade máxima: **clareza e simplicidade** — nada que dificulte o entendimento do usuário.
+
+## Wrapping e tema
+
+- Os componentes **não exigem provider** para renderizar: eles estilizam via **variáveis CSS**
+  (tokens), não via contexto. Renderizam corretos no **tema claro por padrão**.
+- **Dark mode**: defina `data-theme="dark"` num ancestral (ex.: `<html data-theme="dark">`).
+  As semânticas (`--color-surface`, `--color-text`, escala `ink`) invertem sozinhas; os
+  componentes não mudam. No app isso é gerido pelo `ThemeProvider`, mas para construir telas
+  basta o atributo no root.
+- Fonte da marca: **Ubuntu** (já embarcada via `styles.css`; family = `var(--font-sans)`).
+
+## Idioma de estilo: Tailwind v4 com tokens próprios
+
+Estilize com **classes utilitárias Tailwind**. As escalas de cor NÃO são as default do Tailwind —
+use estas famílias (cada uma 50→950):
+
+| Família | Uso | Exemplos de classe |
+|---|---|---|
+| `brand` (turquesa) | ação primária, links, seleção, foco | `bg-brand-600` `text-brand-700` `ring-brand-500` |
+| `ink` (neutros) | texto e superfícies neutras | `text-ink-950` `text-ink-500` `bg-ink-100` |
+| `gold` | pontuação **+3 (cravada)** | `bg-gold-500 text-gold-950` |
+| `grass` | pontuação **+2 (saldo)** | `bg-grass-600 text-white` |
+| `aqua` | pontuação **+1 (acerto)** | `bg-aqua-700 text-white` |
+| `flame` | **perigo / ao vivo apenas** (nunca decorativo) | `bg-flame-600` `text-flame-600` |
+
+Semânticas (trocam no dark, use SEMPRE estas em vez de cor crua):
+`bg-background` (app) < `bg-surface` (cards) < `bg-surface-2` (nav/painéis); borda `border-border`
+ou `ring-border`; texto `text-ink-950` / `text-ink-500` (muted).
+
+Raios: `rounded-xs|sm|md|lg|xl|pill` (pill = totalmente arredondado, usado em botões/badges).
+Sombras (tokens, via arbitrary value): `shadow-[var(--shadow-soft)]` (cards),
+`shadow-[var(--shadow-pop)]` (sheets/menus), `shadow-[var(--shadow-brand)]` (CTA).
+Números de placar/ranking: `tabular-nums`. Nunca `#000`/`#fff` crus para superfícies.
+
+## Onde está a verdade
+
+- Stylesheet do DS: **`styles.css`** (importa `_ds_bundle.css` + tokens) — leia antes de estilizar.
+- Doc por componente: cada `<Name>.prompt.md` (props + exemplos).
+- Filosofia visual completa: `DESIGN.md` do repo (cor OKLCH, motion, bans).
+- Componentes disponíveis em `window.ResultaDS.*` (ex.: `Button`, `Card`, `CardHeader`,
+  `Input`, `Select`, `Combobox`, `Badge`, `ScorePill`, `Avatar`, `Escudo`, `Modal`,
+  `ConfirmDialog`, `ToastProvider`/`useToast`, `SegmentedControl`, `Switch`, `EmptyState`,
+  `Skeleton`, `Spinner`, `Coachmark`, `SortControl`, `ScrollRow`, `CrestMask`, `CrestEditor`).
+
+## Exemplo idiomático
+
+```tsx
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter, Button, ScorePill } from "resultadismo";
+
+<Card>
+  <CardHeader>
+    <CardTitle>Brasileirão — Rodada 12</CardTitle>
+    <CardDescription>Palpites abertos até sábado, 16h.</CardDescription>
+  </CardHeader>
+  <CardContent>
+    <div className="flex items-center gap-2">
+      <span className="text-sm text-ink-700">Seu último acerto:</span>
+      <ScorePill type="cravada" withLabel />
+    </div>
+  </CardContent>
+  <CardFooter>
+    <Button size="sm">Palpitar agora</Button>
+  </CardFooter>
+</Card>
+```
+
+Bans (além dos globais): sem side-stripe borders, sem gradient text, sem glassmorphism
+decorativo, sem grids de cards idênticos, sem modal como primeira opção (prefira inline/sheet).

--- a/.design-sync/entry.ts
+++ b/.design-sync/entry.ts
@@ -1,0 +1,26 @@
+// Barrel de entrada para o design-sync (claude.ai/design).
+// Reexporta os componentes do design system Resultadismo para o bundle
+// window.ResultaDS. NÃO é usado pelo app — só pelo conversor (esbuild resolve
+// os aliases @/ via tsconfig.app.json). Ver .design-sync/config.json.
+export * from "@/components/ui/Avatar";
+export * from "@/components/ui/Badge";
+export * from "@/components/ui/Button";
+export * from "@/components/ui/Card";
+export * from "@/components/ui/Coachmark";
+export * from "@/components/ui/Combobox";
+export * from "@/components/ui/ConfirmDialog";
+export * from "@/components/ui/CrestEditor";
+export * from "@/components/ui/CrestMask";
+export * from "@/components/ui/EmptyState";
+export * from "@/components/ui/Escudo";
+export * from "@/components/ui/Input";
+export * from "@/components/ui/Modal";
+export * from "@/components/ui/ScrollRow";
+export * from "@/components/ui/SegmentedControl";
+export * from "@/components/ui/Select";
+export * from "@/components/ui/Skeleton";
+export * from "@/components/ui/SortControl";
+export * from "@/components/ui/Spinner";
+export * from "@/components/ui/Switch";
+export * from "@/components/ui/Toast";
+export * from "@/components/ScorePill";

--- a/.design-sync/previews/Avatar.tsx
+++ b/.design-sync/previews/Avatar.tsx
@@ -1,0 +1,36 @@
+import { Avatar } from "resultadismo";
+
+const Row = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: "flex", flexWrap: "wrap", gap: 14, alignItems: "center", padding: 16 }}>
+    {children}
+  </div>
+);
+
+export const Tamanhos = () => (
+  <Row>
+    <Avatar name="João Roque" size="xs" />
+    <Avatar name="João Roque" size="sm" />
+    <Avatar name="João Roque" size="md" />
+    <Avatar name="João Roque" size="lg" />
+    <Avatar name="João Roque" size="xl" />
+  </Row>
+);
+
+export const Pessoas = () => (
+  <Row>
+    <Avatar name="Ana Prado" size="lg" />
+    <Avatar name="Bruno Lima" size="lg" />
+    <Avatar name="Carla Souza" size="lg" />
+    <Avatar name="Diego Alves" size="lg" />
+    <Avatar name="Elis Nunes" size="lg" />
+  </Row>
+);
+
+export const EscudosCustom = () => (
+  <Row>
+    <Avatar name="Verdão" src="crest:escudo:3:stripes:verde-dourado:45:" size="lg" />
+    <Avatar name="Rubro" src="crest:escudo:7:stripes:vermelho-grafite:0:" size="lg" />
+    <Avatar name="Tricolor" src="crest:escudo:5:grid:vermelho-gelo-verde-gelo:0:" size="lg" />
+    <Avatar name="Turco" src="crest:escudo:padrao:solid:turquesa:0:" size="lg" />
+  </Row>
+);

--- a/.design-sync/previews/Badge.tsx
+++ b/.design-sync/previews/Badge.tsx
@@ -1,0 +1,27 @@
+import { Badge } from "resultadismo";
+
+const Row = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: "flex", flexWrap: "wrap", gap: 10, alignItems: "center", padding: 16 }}>
+    {children}
+  </div>
+);
+
+export const Tones = () => (
+  <Row>
+    <Badge tone="neutral">Rascunho</Badge>
+    <Badge tone="brand">Sua vez</Badge>
+    <Badge tone="gold">Cravada</Badge>
+    <Badge tone="grass">Saldo</Badge>
+    <Badge tone="aqua">Acerto</Badge>
+    <Badge tone="flame">Ao vivo</Badge>
+    <Badge tone="outline">Encerrado</Badge>
+  </Row>
+);
+
+export const EmContexto = () => (
+  <Row>
+    <Badge tone="brand">3º lugar</Badge>
+    <Badge tone="grass">+12 pts</Badge>
+    <Badge tone="flame">Últimos 5 min</Badge>
+  </Row>
+);

--- a/.design-sync/previews/Button.tsx
+++ b/.design-sync/previews/Button.tsx
@@ -1,0 +1,45 @@
+import { Button } from "resultadismo";
+import { Zap, Check, Plus, Trash2 } from "lucide-react";
+
+const Row = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: "flex", flexWrap: "wrap", gap: 12, alignItems: "center", padding: 16 }}>
+    {children}
+  </div>
+);
+
+export const Variants = () => (
+  <Row>
+    <Button variant="primary">Palpitar</Button>
+    <Button variant="secondary">Entrar</Button>
+    <Button variant="outline">Ver regras</Button>
+    <Button variant="ghost">Depois</Button>
+    <Button variant="danger">Sair da liga</Button>
+  </Row>
+);
+
+export const Sizes = () => (
+  <Row>
+    <Button size="sm">Pequeno</Button>
+    <Button size="md">Médio</Button>
+    <Button size="lg">Grande</Button>
+    <Button size="icon" aria-label="Adicionar"><Plus className="size-4" /></Button>
+  </Row>
+);
+
+export const WithIcons = () => (
+  <Row>
+    <Button variant="primary"><Zap className="size-4" /> Salvar palpite</Button>
+    <Button variant="outline"><Check className="size-4" /> Confirmado</Button>
+    <Button variant="danger"><Trash2 className="size-4" /> Remover</Button>
+  </Row>
+);
+
+export const States = () => (
+  <Row>
+    <Button loading>Salvando…</Button>
+    <Button disabled>Indisponível</Button>
+    <div style={{ width: 220 }}>
+      <Button fullWidth>Confirmar palpite</Button>
+    </div>
+  </Row>
+);

--- a/.design-sync/previews/Card.tsx
+++ b/.design-sync/previews/Card.tsx
@@ -1,0 +1,59 @@
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+  Button,
+  Badge,
+} from "resultadismo";
+
+export const Composed = () => (
+  <div style={{ padding: 16, maxWidth: 380 }}>
+    <Card>
+      <CardHeader>
+        <CardTitle>Brasileirão — Rodada 12</CardTitle>
+        <CardDescription>Palpites abertos até sábado, 16h.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-ink-700">
+          Acerte o placar exato e leve 3 pontos. Saldo ou vencedor também pontuam.
+        </p>
+      </CardContent>
+      <CardFooter>
+        <Button size="sm">Palpitar agora</Button>
+        <Button size="sm" variant="ghost">Ver jogos</Button>
+      </CardFooter>
+    </Card>
+  </div>
+);
+
+export const WithBadge = () => (
+  <div style={{ padding: 16, maxWidth: 380 }}>
+    <Card>
+      <CardHeader>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+          <CardTitle>Sua liga</CardTitle>
+          <Badge tone="brand">3º lugar</Badge>
+        </div>
+        <CardDescription>Amigos do Futebol · 8 participantes</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-ink-700">Faltam 2 rodadas para o fim da temporada.</p>
+      </CardContent>
+    </Card>
+  </div>
+);
+
+export const Bare = () => (
+  <div style={{ padding: 16, maxWidth: 380 }}>
+    <Card>
+      <CardContent>
+        <p className="text-sm text-ink-600">
+          Card simples, sem cabeçalho — só conteúdo sobre a superfície elevada.
+        </p>
+      </CardContent>
+    </Card>
+  </div>
+);

--- a/.design-sync/previews/Coachmark.tsx
+++ b/.design-sync/previews/Coachmark.tsx
@@ -1,0 +1,31 @@
+import { Coachmark, Button } from "resultadismo";
+
+// defaultOpen força o balão aberto (ignora o localStorage), pra vitrine.
+export const DicaPrimeiroAcesso = () => (
+  <div style={{ padding: "24px 24px 150px" }}>
+    <Coachmark
+      defaultOpen
+      storageKey="preview-coachmark-1"
+      title="Crave o placar"
+      content="Toque no jogo e escolha o resultado exato. Acertar em cheio vale 3 pontos."
+      placement="bottom"
+      align="start"
+    >
+      <Button>Flamengo 2 × 1 Palmeiras</Button>
+    </Coachmark>
+  </div>
+);
+
+export const SemTitulo = () => (
+  <div style={{ padding: "24px 24px 150px" }}>
+    <Coachmark
+      defaultOpen
+      storageKey="preview-coachmark-2"
+      content="Arraste para ver as outras rodadas."
+      placement="bottom"
+      align="start"
+    >
+      <Button variant="outline">Rodada 12</Button>
+    </Coachmark>
+  </div>
+);

--- a/.design-sync/previews/Combobox.tsx
+++ b/.design-sync/previews/Combobox.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import { Combobox, Escudo } from "resultadismo";
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ padding: 16, maxWidth: 320, display: "flex", flexDirection: "column", gap: 16 }}>
+    {children}
+  </div>
+);
+
+const TIMES = [
+  { value: "fla", label: "Flamengo", leading: <Escudo name="Flamengo" size="sm" />, hint: "RJ" },
+  { value: "pal", label: "Palmeiras", leading: <Escudo name="Palmeiras" size="sm" />, hint: "SP" },
+  { value: "cru", label: "Cruzeiro", leading: <Escudo name="Cruzeiro" size="sm" />, hint: "MG" },
+  { value: "gre", label: "Grêmio", leading: <Escudo name="Grêmio" size="sm" />, hint: "RS" },
+];
+
+export const TimeSelecionado = () => {
+  const [v, setV] = useState<string | null>("pal");
+  return (
+    <Frame>
+      <Combobox value={v} onChange={setV} options={TIMES} ariaLabel="Time" allowClear />
+    </Frame>
+  );
+};
+
+export const Vazio = () => {
+  const [v, setV] = useState<string | null>(null);
+  return (
+    <Frame>
+      <Combobox value={v} onChange={setV} options={TIMES} placeholder="Buscar time…" ariaLabel="Time" />
+    </Frame>
+  );
+};

--- a/.design-sync/previews/ConfirmDialog.tsx
+++ b/.design-sync/previews/ConfirmDialog.tsx
@@ -1,0 +1,37 @@
+import { ConfirmDialog } from "resultadismo";
+
+// ConfirmDialog é fixed inset-0. O wrapper com `transform` contém o position:fixed
+// para o card renderizar o overlay + diálogo inteiros. No app, use <ConfirmDialog open>.
+const Screen = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ position: "relative", height: 340, transform: "translateZ(0)", overflow: "hidden", borderRadius: 14 }}>
+    {children}
+  </div>
+);
+
+export const Destrutivo = () => (
+  <Screen>
+    <ConfirmDialog
+      open
+      tone="danger"
+      title="Sair da liga?"
+      message="Você perde sua pontuação nesta federação. Esta ação não pode ser desfeita."
+      confirmLabel="Sair da liga"
+      onConfirm={() => {}}
+      onCancel={() => {}}
+    />
+  </Screen>
+);
+
+export const AltoImpacto = () => (
+  <Screen>
+    <ConfirmDialog
+      open
+      tone="warn"
+      title="Encerrar a rodada para todos?"
+      message="Os palpites serão travados e a pontuação, calculada. Avise os participantes antes."
+      confirmLabel="Encerrar rodada"
+      onConfirm={() => {}}
+      onCancel={() => {}}
+    />
+  </Screen>
+);

--- a/.design-sync/previews/CrestEditor.tsx
+++ b/.design-sync/previews/CrestEditor.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { CrestEditor } from "resultadismo";
+
+// Editor completo de escudo/flâmula: estilo (sólido/listras/grade/bola), forma,
+// paleta de cores e rotação. Emite a string crest: via onChange.
+export const Escudo = () => {
+  const [crest, setCrest] = useState<string>("");
+  return (
+    <div style={{ padding: 16, maxWidth: 360 }}>
+      <CrestEditor
+        kind="escudo"
+        name="Amigos FC"
+        initial={crest || "crest:escudo:3:stripes:verde-dourado:45:"}
+        shapes={["padrao", "1", "2", "3", "4", "5", "6", "7"]}
+        allowBall
+        onChange={setCrest}
+      />
+    </div>
+  );
+};
+
+export const Flamula = () => {
+  const [crest, setCrest] = useState<string>("");
+  return (
+    <div style={{ padding: 16, maxWidth: 360 }}>
+      <CrestEditor
+        kind="flamula"
+        name="Zona Norte"
+        initial={crest || "crest:flamula:2:grid:azul-gelo-azul-gelo:0:"}
+        shapes={["1", "2", "3"]}
+        allowBall
+        onChange={setCrest}
+      />
+    </div>
+  );
+};

--- a/.design-sync/previews/CrestMask.tsx
+++ b/.design-sync/previews/CrestMask.tsx
@@ -1,0 +1,34 @@
+import { CrestMask } from "resultadismo";
+
+const Row = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: "flex", flexWrap: "wrap", gap: 14, alignItems: "center", padding: 16 }}>
+    {children}
+  </div>
+);
+
+export const EscudoComInicial = () => (
+  <Row>
+    <CrestMask name="João" px={56} defaultKind="escudo" withLetter />
+    <CrestMask name="Ana" px={56} defaultKind="escudo" withLetter />
+    <CrestMask name="Rui" px={56} defaultKind="escudo" withLetter />
+    <CrestMask name="Bia" px={56} defaultKind="escudo" withLetter />
+  </Row>
+);
+
+export const Flamula = () => (
+  <Row>
+    <CrestMask name="Grupo" px={56} defaultKind="flamula" />
+    <CrestMask src="crest:flamula:2:stripes:verde-dourado:45:" name="G" px={56} defaultKind="flamula" />
+    <CrestMask src="crest:flamula:3:grid:azul-gelo-azul-gelo:0:" name="G" px={56} defaultKind="flamula" />
+    <CrestMask src="crest:flamula:1:ball:grafite-dourado:0:" name="G" px={56} defaultKind="flamula" />
+  </Row>
+);
+
+export const Tamanhos = () => (
+  <Row>
+    <CrestMask name="Time" px={28} defaultKind="escudo" withLetter />
+    <CrestMask name="Time" px={40} defaultKind="escudo" withLetter />
+    <CrestMask name="Time" px={64} defaultKind="escudo" withLetter />
+    <CrestMask name="Time" px={88} defaultKind="escudo" withLetter />
+  </Row>
+);

--- a/.design-sync/previews/EmptyState.tsx
+++ b/.design-sync/previews/EmptyState.tsx
@@ -1,0 +1,38 @@
+import { EmptyState, Button } from "resultadismo";
+import { Inbox, Trophy, Search } from "lucide-react";
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ padding: 16, maxWidth: 420 }}>{children}</div>
+);
+
+export const SemPalpites = () => (
+  <Frame>
+    <EmptyState
+      icon={<Inbox className="size-7" />}
+      title="Nenhum palpite ainda"
+      description="Escolha um jogo da rodada e crave o placar para começar a pontuar."
+      action={<Button size="sm">Ver jogos da rodada</Button>}
+    />
+  </Frame>
+);
+
+export const SemResultados = () => (
+  <Frame>
+    <EmptyState
+      icon={<Search className="size-7" />}
+      title="Nada encontrado"
+      description="Tente outro termo ou remova os filtros da busca."
+    />
+  </Frame>
+);
+
+export const SemLigas = () => (
+  <Frame>
+    <EmptyState
+      icon={<Trophy className="size-7" />}
+      title="Você ainda não está em nenhuma liga"
+      description="Crie a sua federação ou entre com um código de convite."
+      action={<Button size="sm" variant="outline">Entrar com código</Button>}
+    />
+  </Frame>
+);

--- a/.design-sync/previews/Escudo.tsx
+++ b/.design-sync/previews/Escudo.tsx
@@ -1,0 +1,34 @@
+import { Escudo } from "resultadismo";
+
+const Row = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: "flex", flexWrap: "wrap", gap: 14, alignItems: "center", padding: 16 }}>
+    {children}
+  </div>
+);
+
+export const Tamanhos = () => (
+  <Row>
+    <Escudo name="Grupo A" size="sm" />
+    <Escudo name="Grupo A" size="md" />
+    <Escudo name="Grupo A" size="lg" />
+    <Escudo name="Grupo A" size="xl" />
+  </Row>
+);
+
+export const Flamulas = () => (
+  <Row>
+    <Escudo name="Amigos FC" size="lg" />
+    <Escudo name="Zona Norte" size="lg" />
+    <Escudo name="Baixada" size="lg" />
+    <Escudo name="Peladeiros" size="lg" />
+  </Row>
+);
+
+export const Preenchimentos = () => (
+  <Row>
+    <Escudo name="Sólido" src="crest:flamula:1:solid:azul:0:" size="lg" />
+    <Escudo name="Listras" src="crest:flamula:2:stripes:verde-dourado:45:" size="lg" />
+    <Escudo name="Grade" src="crest:flamula:3:grid:vermelho-gelo-vermelho-gelo:0:" size="lg" />
+    <Escudo name="Bola" src="crest:flamula:1:ball:grafite-dourado:0:" size="lg" />
+  </Row>
+);

--- a/.design-sync/previews/Input.tsx
+++ b/.design-sync/previews/Input.tsx
@@ -1,0 +1,38 @@
+import { Input } from "resultadismo";
+import { Search, Mail, User } from "lucide-react";
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ padding: 16, maxWidth: 340, display: "flex", flexDirection: "column", gap: 16 }}>
+    {children}
+  </div>
+);
+
+export const WithLabel = () => (
+  <Frame>
+    <Input label="Nome do time" placeholder="Ex.: Amigos FC" />
+  </Frame>
+);
+
+export const WithIcon = () => (
+  <Frame>
+    <Input icon={<Search className="size-4" />} placeholder="Buscar liga…" />
+    <Input icon={<Mail className="size-4" />} label="E-mail" placeholder="voce@email.com" />
+  </Frame>
+);
+
+export const WithError = () => (
+  <Frame>
+    <Input
+      label="Apelido"
+      icon={<User className="size-4" />}
+      defaultValue="jr"
+      error="Mínimo de 3 caracteres."
+    />
+  </Frame>
+);
+
+export const Disabled = () => (
+  <Frame>
+    <Input label="Código da liga" value="RES-2026" disabled />
+  </Frame>
+);

--- a/.design-sync/previews/Modal.tsx
+++ b/.design-sync/previews/Modal.tsx
@@ -1,0 +1,27 @@
+import { Modal, Button, CardTitle, CardDescription } from "resultadismo";
+
+// O Modal é fixed inset-0 (tela cheia). O wrapper com `transform` vira o bloco
+// de contenção do position:fixed, então o overlay + painel renderizam DENTRO do
+// card (em vez de escapar). No app, use <Modal open> normalmente.
+const Screen = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ position: "relative", height: 320, transform: "translateZ(0)", overflow: "hidden", borderRadius: 14 }}>
+    {children}
+  </div>
+);
+
+export const Aberto = () => (
+  <Screen>
+    <Modal open onClose={() => {}} label="Confirmar palpite">
+      <div style={{ padding: 20, display: "flex", flexDirection: "column", gap: 12 }}>
+        <CardTitle>Confirmar palpite</CardTitle>
+        <CardDescription>
+          Flamengo 2 × 1 Palmeiras — você não poderá alterar depois que a partida começar.
+        </CardDescription>
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 8 }}>
+          <Button variant="ghost" size="sm">Voltar</Button>
+          <Button size="sm">Cravar placar</Button>
+        </div>
+      </div>
+    </Modal>
+  </Screen>
+);

--- a/.design-sync/previews/ScorePill.tsx
+++ b/.design-sync/previews/ScorePill.tsx
@@ -1,0 +1,33 @@
+import { ScorePill } from "resultadismo";
+
+const Row = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: "flex", flexWrap: "wrap", gap: 10, alignItems: "center", padding: 16 }}>
+    {children}
+  </div>
+);
+
+export const Tipos = () => (
+  <Row>
+    <ScorePill type="cravada" />
+    <ScorePill type="saldo" />
+    <ScorePill type="acerto" />
+    <ScorePill type="erro" />
+  </Row>
+);
+
+export const ComRotulo = () => (
+  <Row>
+    <ScorePill type="cravada" withLabel />
+    <ScorePill type="saldo" withLabel />
+    <ScorePill type="acerto" withLabel />
+    <ScorePill type="erro" withLabel />
+  </Row>
+);
+
+export const Joker = () => (
+  <Row>
+    <ScorePill type="cravada" doubled />
+    <ScorePill type="saldo" doubled withLabel />
+    <ScorePill type="acerto" doubled />
+  </Row>
+);

--- a/.design-sync/previews/ScrollRow.tsx
+++ b/.design-sync/previews/ScrollRow.tsx
@@ -1,0 +1,27 @@
+import { ScrollRow, Badge } from "resultadismo";
+
+// Fileira mais larga que o container → o degradê das bordas indica que há mais
+// conteúdo para arrastar.
+export const Rodadas = () => (
+  <div style={{ padding: 16, maxWidth: 320 }}>
+    <ScrollRow innerClassName="px-1 py-1">
+      {Array.from({ length: 14 }).map((_, i) => (
+        <Badge key={i} tone={i === 3 ? "brand" : "neutral"}>
+          Rodada {i + 1}
+        </Badge>
+      ))}
+    </ScrollRow>
+  </div>
+);
+
+export const Times = () => (
+  <div style={{ padding: 16, maxWidth: 320 }}>
+    <ScrollRow innerClassName="px-1 py-1">
+      {["Flamengo", "Palmeiras", "Cruzeiro", "Grêmio", "Bahia", "Santos", "Vasco"].map((t) => (
+        <Badge key={t} tone="outline">
+          {t}
+        </Badge>
+      ))}
+    </ScrollRow>
+  </div>
+);

--- a/.design-sync/previews/SegmentedControl.tsx
+++ b/.design-sync/previews/SegmentedControl.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { SegmentedControl } from "resultadismo";
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: "flex", flexDirection: "column", gap: 18, padding: 16, maxWidth: 360 }}>
+    {children}
+  </div>
+);
+
+export const DuasOpcoes = () => {
+  const [v, setV] = useState("meus");
+  return (
+    <Frame>
+      <SegmentedControl
+        value={v}
+        onChange={setV}
+        options={[
+          { value: "meus", label: "Meus palpites" },
+          { value: "todos", label: "Todos os jogos" },
+        ]}
+      />
+    </Frame>
+  );
+};
+
+export const VariasOpcoes = () => {
+  const [v, setV] = useState("rodada");
+  return (
+    <Frame>
+      <SegmentedControl
+        value={v}
+        onChange={setV}
+        options={[
+          { value: "rodada", label: "Rodada" },
+          { value: "mes", label: "Mês" },
+          { value: "geral", label: "Geral" },
+        ]}
+      />
+    </Frame>
+  );
+};

--- a/.design-sync/previews/Select.tsx
+++ b/.design-sync/previews/Select.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { Select } from "resultadismo";
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ padding: 16, maxWidth: 300, display: "flex", flexDirection: "column", gap: 16 }}>
+    {children}
+  </div>
+);
+
+const OPCOES = [
+  { value: "rodada", label: "Esta rodada", hint: "10 jogos" },
+  { value: "mes", label: "Este mês", hint: "42 jogos" },
+  { value: "temporada", label: "Temporada", hint: "380 jogos" },
+];
+
+export const Selecionado = () => {
+  const [v, setV] = useState<string | null>("rodada");
+  return (
+    <Frame>
+      <Select value={v} onChange={setV} options={OPCOES} ariaLabel="Período" />
+    </Frame>
+  );
+};
+
+export const Placeholder = () => {
+  const [v, setV] = useState<string | null>(null);
+  return (
+    <Frame>
+      <Select value={v} onChange={setV} options={OPCOES} placeholder="Escolha o período…" ariaLabel="Período" />
+    </Frame>
+  );
+};
+
+export const Desabilitado = () => (
+  <Frame>
+    <Select value="temporada" onChange={() => {}} options={OPCOES} disabled ariaLabel="Período" />
+  </Frame>
+);

--- a/.design-sync/previews/Skeleton.tsx
+++ b/.design-sync/previews/Skeleton.tsx
@@ -1,0 +1,37 @@
+import { Skeleton } from "resultadismo";
+
+// Skeleton só aceita className; o tamanho vem do wrapper (inline) + h-full/w-full.
+const Bar = ({ w, h = 12 }: { w: number | string; h?: number }) => (
+  <div style={{ width: w, height: h }}>
+    <Skeleton className="h-full w-full" />
+  </div>
+);
+
+export const CartaoDeJogo = () => (
+  <div style={{ padding: 16, maxWidth: 360 }}>
+    <div
+      className="rounded-lg bg-surface shadow-[var(--shadow-soft)] ring-1 ring-border"
+      style={{ padding: 16, display: "flex", flexDirection: "column", gap: 12 }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        <div style={{ width: 44, height: 44 }}>
+          <Skeleton className="size-full rounded-full" />
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, flex: 1 }}>
+          <Bar w="60%" />
+          <Bar w="40%" />
+        </div>
+      </div>
+      <Bar w="100%" h={40} />
+    </div>
+  </div>
+);
+
+export const Linhas = () => (
+  <div style={{ padding: 16, maxWidth: 360, display: "flex", flexDirection: "column", gap: 10 }}>
+    <Bar w="92%" h={14} />
+    <Bar w="75%" h={14} />
+    <Bar w="80%" h={14} />
+    <Bar w="50%" h={14} />
+  </div>
+);

--- a/.design-sync/previews/SortControl.tsx
+++ b/.design-sync/previews/SortControl.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { SortControl } from "resultadismo";
+
+type Key = "pontos" | "nome" | "rodada";
+const FIELDS = [
+  { key: "pontos" as Key, label: "Pontos", ascLabel: "Menos", descLabel: "Mais" },
+  { key: "nome" as Key, label: "Nome", ascLabel: "A→Z", descLabel: "Z→A" },
+  { key: "rodada" as Key, label: "Rodada", ascLabel: "Antigas", descLabel: "Recentes" },
+];
+
+export const Ranking = () => {
+  const [value, setValue] = useState<Key>("pontos");
+  const [dir, setDir] = useState<"asc" | "desc">("desc");
+  return (
+    <div style={{ padding: 16, maxWidth: 420 }}>
+      <SortControl
+        fields={FIELDS}
+        value={value}
+        dir={dir}
+        onChange={(k, d) => {
+          setValue(k);
+          setDir(d);
+        }}
+      />
+    </div>
+  );
+};
+
+export const PorNome = () => {
+  const [value, setValue] = useState<Key>("nome");
+  const [dir, setDir] = useState<"asc" | "desc">("asc");
+  return (
+    <div style={{ padding: 16, maxWidth: 420 }}>
+      <SortControl fields={FIELDS} value={value} dir={dir} onChange={(k, d) => { setValue(k); setDir(d); }} />
+    </div>
+  );
+};

--- a/.design-sync/previews/Spinner.tsx
+++ b/.design-sync/previews/Spinner.tsx
@@ -1,0 +1,16 @@
+import { Spinner } from "resultadismo";
+
+export const Tamanhos = () => (
+  <div style={{ display: "flex", gap: 20, alignItems: "center", padding: 24 }}>
+    <Spinner className="size-4" />
+    <Spinner className="size-5" />
+    <Spinner className="size-7" />
+  </div>
+);
+
+export const EmBotao = () => (
+  <div style={{ display: "flex", gap: 10, alignItems: "center", padding: 24, color: "var(--color-ink-500)" }}>
+    <Spinner className="size-5" />
+    <span className="text-sm text-ink-500">Carregando rodada…</span>
+  </div>
+);

--- a/.design-sync/previews/Switch.tsx
+++ b/.design-sync/previews/Switch.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import { Switch } from "resultadismo";
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: "flex", flexDirection: "column", gap: 18, padding: 16, maxWidth: 320 }}>
+    {children}
+  </div>
+);
+
+const Linha = ({ text, node }: { text: string; node: React.ReactNode }) => (
+  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+    <span className="text-sm text-ink-800">{text}</span>
+    {node}
+  </div>
+);
+
+export const LigadoDesligado = () => {
+  const [a, setA] = useState(true);
+  const [b, setB] = useState(false);
+  return (
+    <Frame>
+      <Linha text="Notificar novos jogos" node={<Switch checked={a} onChange={setA} label="Notificar novos jogos" />} />
+      <Linha text="Resumo semanal por e-mail" node={<Switch checked={b} onChange={setB} label="Resumo semanal" />} />
+    </Frame>
+  );
+};
+
+export const Desabilitado = () => (
+  <Frame>
+    <Linha text="Modo espectador (em breve)" node={<Switch checked={false} onChange={() => {}} label="Modo espectador" disabled />} />
+    <Linha text="Sincronização premium" node={<Switch checked onChange={() => {}} label="Sincronização premium" disabled />} />
+  </Frame>
+);

--- a/.design-sync/previews/ToastProvider.tsx
+++ b/.design-sync/previews/ToastProvider.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import { ToastProvider, useToast, Button } from "resultadismo";
+
+// Os toasts sobem no topo (portal fixo). O preview dispara os três tons na
+// montagem para a vitrine; no app, chame useToast().toast(msg, tone).
+function Disparar() {
+  const { toast } = useToast();
+  useEffect(() => {
+    toast("Palpite salvo!", "success");
+    const t1 = setTimeout(() => toast("Não foi possível salvar.", "error"), 50);
+    const t2 = setTimeout(() => toast("A rodada encerra em 1 hora.", "info"), 100);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, [toast]);
+  return (
+    <div style={{ padding: "120px 24px 24px", display: "flex", justifyContent: "center" }}>
+      <Button variant="outline">Salvar palpite</Button>
+    </div>
+  );
+}
+
+export const Toasts = () => (
+  <ToastProvider>
+    <Disparar />
+  </ToastProvider>
+);

--- a/.design-sync/shims/crest.ts
+++ b/.design-sync/shims/crest.ts
@@ -1,0 +1,321 @@
+// GERADO por .design-sync/shims/gen-crest-shim.mjs — NÃO editar à mão.
+// Espelho de src/lib/crest.ts com import.meta.glob → imports estáticos.
+
+import __e0 from "@/assets/escudos/escudo-1.svg";
+import __e1 from "@/assets/escudos/escudo-10.svg";
+import __e2 from "@/assets/escudos/escudo-11.svg";
+import __e3 from "@/assets/escudos/escudo-12.svg";
+import __e4 from "@/assets/escudos/escudo-13.svg";
+import __e5 from "@/assets/escudos/escudo-14.svg";
+import __e6 from "@/assets/escudos/escudo-15.svg";
+import __e7 from "@/assets/escudos/escudo-16.svg";
+import __e8 from "@/assets/escudos/escudo-2.svg";
+import __e9 from "@/assets/escudos/escudo-3.svg";
+import __e10 from "@/assets/escudos/escudo-4.svg";
+import __e11 from "@/assets/escudos/escudo-5.svg";
+import __e12 from "@/assets/escudos/escudo-6.svg";
+import __e13 from "@/assets/escudos/escudo-7.svg";
+import __e14 from "@/assets/escudos/escudo-8.svg";
+import __e15 from "@/assets/escudos/escudo-9.svg";
+import __e16 from "@/assets/escudos/escudo-padrao.svg";
+import __f0 from "@/assets/grupos/flamula-1.svg";
+import __f1 from "@/assets/grupos/flamula-2.svg";
+import __f2 from "@/assets/grupos/flamula-3.svg";
+
+// Sistema de escudos/flâmulas baseado em MÁSCARA de SVG.
+// O SVG (em /public/escudos ou /public/grupos) recorta um fundo de cor
+// (sólido, listras, grade ou bola) ou uma foto. A identidade visual fica
+// codificada numa string `crest:` salva em profiles.avatar_url e leagues.logo_url.
+//
+// Formato (posicional, separado por ":"):
+//   crest:<kind>:<shape>:<fill>:<cor1-cor2-...>:<rotação>:<fotoEncoded>
+// Ex.: crest:escudo:padrao:stripes:verde-dourado:45:
+//      crest:flamula:2:ball:azul-dourado:0:
+//      crest:escudo:3:photo:grafite::https%3A%2F%2F...
+//
+// A foto é encodeURIComponent — então nunca contém ":" e não quebra o split.
+import { AVATAR_COLORS, parseGenAvatar } from "@/lib/avatar";
+
+export type CrestKind = "escudo" | "flamula";
+export type CrestFill = "solid" | "stripes" | "grid" | "ball" | "photo";
+const CREST_FILLS: readonly CrestFill[] = ["solid", "stripes", "grid", "ball", "photo"];
+
+// ---------------------------------------------------------------------------
+// Catálogo de formas — montado AUTOMATICAMENTE a partir das pastas:
+//   src/assets/escudos/escudo-<id>.svg    (perfil; "escudo-padrao" é o default)
+//   src/assets/grupos/flamula-<id>.svg (grupo)
+// Pra adicionar/remover/trocar uma forma, é só largar/apagar o SVG na pasta
+// (nome no padrão "escudo-<id>.svg" / "flamula-<id>.svg") e rebuildar. O <id>
+// vira o identificador salvo no crest, então mantenha nomes estáveis.
+// import.meta.glob lê em tempo de build (Vite não enxerga a pasta public).
+// ---------------------------------------------------------------------------
+const ESCUDO_FILES: Record<string, string> = {
+  "../assets/escudos/escudo-1.svg": __e0,
+  "../assets/escudos/escudo-10.svg": __e1,
+  "../assets/escudos/escudo-11.svg": __e2,
+  "../assets/escudos/escudo-12.svg": __e3,
+  "../assets/escudos/escudo-13.svg": __e4,
+  "../assets/escudos/escudo-14.svg": __e5,
+  "../assets/escudos/escudo-15.svg": __e6,
+  "../assets/escudos/escudo-16.svg": __e7,
+  "../assets/escudos/escudo-2.svg": __e8,
+  "../assets/escudos/escudo-3.svg": __e9,
+  "../assets/escudos/escudo-4.svg": __e10,
+  "../assets/escudos/escudo-5.svg": __e11,
+  "../assets/escudos/escudo-6.svg": __e12,
+  "../assets/escudos/escudo-7.svg": __e13,
+  "../assets/escudos/escudo-8.svg": __e14,
+  "../assets/escudos/escudo-9.svg": __e15,
+  "../assets/escudos/escudo-padrao.svg": __e16,
+};
+const FLAMULA_FILES: Record<string, string> = {
+  "../assets/grupos/flamula-1.svg": __f0,
+  "../assets/grupos/flamula-2.svg": __f1,
+  "../assets/grupos/flamula-3.svg": __f2,
+};
+
+// id (estável) -> url empacotada. id = nome sem o prefixo e sem ".svg".
+function buildCatalog(files: Record<string, string>, prefix: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const [path, url] of Object.entries(files)) {
+    const stem = (path.split("/").pop() ?? "").replace(/\.svg$/i, "");
+    const id = stem.startsWith(`${prefix}-`) ? stem.slice(prefix.length + 1) : stem;
+    if (id) map.set(id, url);
+  }
+  return map;
+}
+
+// "padrao" primeiro; depois numéricos crescentes; depois alfabético.
+function sortShapeIds(ids: string[]): string[] {
+  return [...ids].sort((a, b) => {
+    if (a === "padrao") return -1;
+    if (b === "padrao") return 1;
+    const na = Number(a);
+    const nb = Number(b);
+    const aNum = a !== "" && !Number.isNaN(na);
+    const bNum = b !== "" && !Number.isNaN(nb);
+    if (aNum && bNum) return na - nb;
+    if (aNum) return -1;
+    if (bNum) return 1;
+    return a.localeCompare(b);
+  });
+}
+
+const ESCUDO_CATALOG = buildCatalog(ESCUDO_FILES, "escudo");
+const FLAMULA_CATALOG = buildCatalog(FLAMULA_FILES, "flamula");
+
+export const ESCUDO_SHAPES: string[] = sortShapeIds([...ESCUDO_CATALOG.keys()]);
+export const FLAMULA_SHAPES: string[] = sortShapeIds([...FLAMULA_CATALOG.keys()]);
+
+// Default de cada tipo (resiliente: usa "padrao" se existir, senão a 1ª forma).
+export const DEFAULT_ESCUDO_SHAPE =
+  ESCUDO_CATALOG.has("padrao") ? "padrao" : ESCUDO_SHAPES[0] ?? "padrao";
+export const DEFAULT_FLAMULA_SHAPE = FLAMULA_SHAPES[0] ?? "1";
+
+/** URL empacotada da forma. Cai no default se o id não existir mais (forma removida). */
+export function crestShapeUrl(kind: CrestKind, shape: string): string {
+  const catalog = kind === "flamula" ? FLAMULA_CATALOG : ESCUDO_CATALOG;
+  const fallback = kind === "flamula" ? DEFAULT_FLAMULA_SHAPE : DEFAULT_ESCUDO_SHAPE;
+  return catalog.get(shape) ?? catalog.get(fallback) ?? "";
+}
+
+// ---------------------------------------------------------------------------
+// Cores (reaproveita a paleta do avatar)
+// ---------------------------------------------------------------------------
+export const CREST_COLORS = AVATAR_COLORS;
+export const CREST_ROTATIONS = [0, 45, 90, 135];
+
+function hexOf(key: string): string {
+  return AVATAR_COLORS.find((c) => c.key === key)?.hex ?? AVATAR_COLORS[0]!.hex;
+}
+function isDark(key: string): boolean {
+  return !!AVATAR_COLORS.find((c) => c.key === key)?.dark;
+}
+
+// ---------------------------------------------------------------------------
+// Config + encode/parse
+// ---------------------------------------------------------------------------
+export type CrestConfig = {
+  kind: CrestKind;
+  shape: string;
+  fill: CrestFill;
+  colors: string[];
+  rotation: number;
+  photo?: string;
+};
+
+export function isCrest(src: string | null | undefined): boolean {
+  return !!src && src.startsWith("crest:");
+}
+
+export function buildCrest(cfg: CrestConfig): string {
+  const colors = cfg.colors.join("-");
+  const photo = cfg.fill === "photo" && cfg.photo ? encodeURIComponent(cfg.photo) : "";
+  return `crest:${cfg.kind}:${cfg.shape}:${cfg.fill}:${colors}:${Math.round(cfg.rotation)}:${photo}`;
+}
+
+export function parseCrest(src: string | null | undefined): CrestConfig | null {
+  if (!isCrest(src)) return null;
+  const parts = src!.split(":");
+  const kind: CrestKind = parts[1] === "flamula" ? "flamula" : "escudo";
+  const shape = parts[2] || (kind === "flamula" ? DEFAULT_FLAMULA_SHAPE : DEFAULT_ESCUDO_SHAPE);
+  const fill: CrestFill = CREST_FILLS.includes(parts[3] as CrestFill)
+    ? (parts[3] as CrestFill)
+    : "solid";
+  const colors = (parts[4] || "").split("-").filter(Boolean);
+  const rotation = Number.parseInt(parts[5] ?? "0", 10) || 0;
+  // foto vem encodada e sem ":", mas faço join por segurança.
+  const photoEnc = parts.slice(6).join(":");
+  // sanitiza: avatar_url/logo_url são texto livre escrito pelo usuário; sem isso,
+  // uma foto forjada quebra o url("...") do CSS e injeta background (CSS injection).
+  const photo = photoEnc ? sanitizePhotoUrl(safeDecode(photoEnc)) : undefined;
+  return {
+    kind,
+    shape,
+    fill,
+    colors: colors.length ? colors : ["turquesa"],
+    rotation,
+    photo,
+  };
+}
+
+function safeDecode(s: string): string | undefined {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Sanitiza a URL da foto antes de virar CSS `url(...)`. Rejeita qualquer coisa que
+ * quebre o `url("...")` ou injete outra declaração (aspas, parênteses, espaço, `;`,
+ * `<`, `>`, barra invertida) e só aceita http(s) absoluto. Caso contrário → undefined
+ * (o render cai no fundo sólido). Defesa contra CSS injection armazenada.
+ */
+function sanitizePhotoUrl(raw: string | null | undefined): string | undefined {
+  if (!raw) return undefined;
+  const s = raw.trim();
+  if (!s || /[\s"'()\\;<>]/.test(s)) return undefined;
+  try {
+    const u = new URL(s);
+    if (u.protocol === "https:" || u.protocol === "http:") return u.href;
+  } catch {
+    // não é URL absoluta válida
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+// Hash estável (djb2) p/ defaults determinísticos a partir do nome.
+function hashStr(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = (h * 33) ^ s.charCodeAt(i);
+  return Math.abs(h | 0);
+}
+
+/** Default de todo mundo: escudo padrão (recorte da logo) com cor estável do nome. */
+export function defaultCrestFromName(
+  name: string | null | undefined,
+  kind: CrestKind = "escudo",
+): CrestConfig {
+  const h = hashStr(name ?? "Resultadismo");
+  const color = AVATAR_COLORS[h % AVATAR_COLORS.length]!.key;
+  if (kind === "flamula") {
+    const c2 = AVATAR_COLORS[(h >> 3) % AVATAR_COLORS.length]!.key;
+    return {
+      kind,
+      shape: DEFAULT_FLAMULA_SHAPE,
+      fill: c2 === color ? "solid" : "stripes",
+      colors: c2 === color ? [color] : [color, c2],
+      rotation: 0,
+    };
+  }
+  return { kind, shape: DEFAULT_ESCUDO_SHAPE, fill: "solid", colors: [color], rotation: 0 };
+}
+
+/**
+ * Normaliza QUALQUER avatar_url antigo para um crest de escudo — ninguém fica
+ * sem escudo:
+ *  - crest:...      → passa direto
+ *  - gen:...        → escudo com as cores do avatar antigo
+ *  - foto crua (URL)→ escudo recortando a foto
+ *  - null/vazio     → null (o render usa o default determinístico do nome)
+ */
+export function legacyToCrest(src: string | null | undefined): string | null {
+  if (!src) return null;
+  if (isCrest(src)) return src;
+  if (src.startsWith("gen:")) {
+    const g = parseGenAvatar(src);
+    const colors = g?.colors?.length ? g.colors : ["turquesa"];
+    return buildCrest({
+      kind: "escudo",
+      shape: DEFAULT_ESCUDO_SHAPE,
+      fill: colors.length > 1 ? "stripes" : "solid",
+      colors,
+      rotation: g?.rotation ?? 0,
+    });
+  }
+  // sobra: foto crua (URL do Google salva direto) → recorta no escudo padrão
+  return buildCrest({
+    kind: "escudo",
+    shape: DEFAULT_ESCUDO_SHAPE,
+    fill: "photo",
+    colors: ["turquesa"],
+    rotation: 0,
+    photo: src,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Render do fundo (CSS background) para a config
+// ---------------------------------------------------------------------------
+/** background CSS que será recortado pela máscara do SVG. */
+export function crestBackground(cfg: CrestConfig): string {
+  const c = cfg.colors.map(hexOf);
+  const rot = cfg.rotation;
+  switch (cfg.fill) {
+    case "photo": {
+      // sanitiza no sink (cobre qualquer caller, não só o que passou por parseCrest);
+      // sem foto válida cai num sólido (a letra entra por cima no Avatar)
+      const safe = sanitizePhotoUrl(cfg.photo);
+      return safe ? `center / cover no-repeat url("${safe}")` : c[0] ?? hexOf("turquesa");
+    }
+    case "stripes":
+      if (c.length <= 1) return c[0] ?? hexOf("turquesa");
+      if (c.length === 2)
+        return `linear-gradient(${rot}deg, ${c[0]} 0 50%, ${c[1]} 50% 100%)`;
+      return `linear-gradient(${rot}deg, ${c[0]} 0 33.34%, ${c[1]} 33.34% 66.67%, ${c[2]} 66.67% 100%)`;
+    case "grid": {
+      // 2x2 via conic-gradient. Ordem das cores em leitura natural:
+      // [0]=sup-esq, [1]=sup-dir, [2]=inf-esq, [3]=inf-dir.
+      // Setores do conic (from 0deg): 0–90=sup-dir, 90–180=inf-dir,
+      // 180–270=inf-esq, 270–360=sup-esq.
+      const tl = c[0];
+      const tr = c[1] ?? c[0];
+      const bl = c[2] ?? c[0];
+      const br = c[3] ?? c[1] ?? c[0];
+      return `conic-gradient(from ${rot}deg at 50% 50%, ${tr} 0 90deg, ${br} 90deg 180deg, ${bl} 180deg 270deg, ${tl} 270deg 360deg)`;
+    }
+    case "ball": {
+      // fundo + bola central (flâmula). cor2 = bola, cor1 = fundo.
+      const bg = c[0] ?? hexOf("verde");
+      const ball = c[1] ?? hexOf("dourado");
+      return `radial-gradient(circle at 50% 50%, ${ball} 0 30%, ${bg} 30.5% 100%)`;
+    }
+    case "solid":
+    default:
+      return c[0] ?? hexOf("turquesa");
+  }
+}
+
+/** cor de texto da inicial (perfil) — contraste sobre o fundo. */
+export function crestTextColor(cfg: CrestConfig): string {
+  // multicolor / grade / foto: branco com sombra; sólido: contraste pela cor.
+  if (cfg.fill === "solid" || (cfg.fill === "photo" && !cfg.photo)) {
+    return isDark(cfg.colors[0] ?? "") ? "#232323" : "#ffffff";
+  }
+  return "#ffffff";
+}

--- a/.design-sync/shims/gen-crest-shim.mjs
+++ b/.design-sync/shims/gen-crest-shim.mjs
@@ -1,0 +1,57 @@
+// Gera .design-sync/shims/crest.ts a partir de src/lib/crest.ts, trocando os
+// dois import.meta.glob (macro exclusiva do Vite, que quebra o esbuild do
+// design-sync — vira undefined e joga TypeError na carga do IIFE, matando o
+// bundle inteiro) por imports ESTÁTICOS dos 20 SVGs. O esbuild do conversor
+// tem loader .svg='dataurl', então cada SVG entra inline como data-URL e os
+// escudos renderizam de verdade nos previews (Escudo/CrestMask/Avatar/CrestEditor).
+//
+// Reprodutível: rode de novo se os SVGs em src/assets/{escudos,grupos} mudarem.
+//   node .design-sync/shims/gen-crest-shim.mjs
+// Ver .design-sync/NOTES.md.
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repo = resolve(here, "..", "..");
+const src = readFileSync(resolve(repo, "src/lib/crest.ts"), "utf8");
+
+function svgs(dir) {
+  return readdirSync(resolve(repo, dir))
+    .filter((f) => f.endsWith(".svg"))
+    .sort();
+}
+const escudos = svgs("src/assets/escudos");
+const grupos = svgs("src/assets/grupos");
+
+let imports = "";
+let escMap = [];
+let flaMap = [];
+escudos.forEach((f, i) => {
+  imports += `import __e${i} from "@/assets/escudos/${f}";\n`;
+  escMap.push(`  "../assets/escudos/${f}": __e${i},`);
+});
+grupos.forEach((f, i) => {
+  imports += `import __f${i} from "@/assets/grupos/${f}";\n`;
+  flaMap.push(`  "../assets/grupos/${f}": __f${i},`);
+});
+
+const escBlock =
+  `const ESCUDO_FILES: Record<string, string> = {\n${escMap.join("\n")}\n};`;
+const flaBlock =
+  `const FLAMULA_FILES: Record<string, string> = {\n${flaMap.join("\n")}\n};`;
+
+let out = src
+  // avatar mora em src/lib; do shim (.design-sync/shims) o caminho relativo muda.
+  .replace(/from "\.\/avatar"/, 'from "@/lib/avatar"')
+  // troca os dois import.meta.glob por mapas estáticos.
+  .replace(/const ESCUDO_FILES = import\.meta\.glob\([\s\S]*?\}\) as Record<string, string>;/, escBlock)
+  .replace(/const FLAMULA_FILES = import\.meta\.glob\([\s\S]*?\}\) as Record<string, string>;/, flaBlock);
+
+const header =
+  "// GERADO por .design-sync/shims/gen-crest-shim.mjs — NÃO editar à mão.\n" +
+  "// Espelho de src/lib/crest.ts com import.meta.glob → imports estáticos.\n\n";
+
+out = header + imports + "\n" + out;
+writeFileSync(resolve(here, "crest.ts"), out);
+console.log(`crest shim: ${escudos.length} escudos + ${grupos.length} grupos → .design-sync/shims/crest.ts`);

--- a/.design-sync/tsconfig.paths.json
+++ b/.design-sync/tsconfig.paths.json
@@ -1,0 +1,10 @@
+{
+  "comment": "tsconfig minimo so com o alias @/ para o esbuild do design-sync. Nao usar tsconfig.app.json aqui: seus globs include/exclude com /**/_* quebram o comment-stripper do tsconfigPathsPlugin (le /* ... */ como comentario e apaga paths). Ver .design-sync/NOTES.md.",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/lib/crest": ["./shims/crest.ts"],
+      "@/*": ["../src/*"]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ test-results/
 playwright-report/
 .vite-redesign/
 .fuse_hidden*
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules
+.design-sync/compiled-tailwind.css


### PR DESCRIPTION
Empacota os 22 componentes do design system (src/components/ui/* + ScorePill) para o formato do claude.ai/design (shape=package, synth-entry via barrel), com previews autorados e verificados, tokens Tailwind v4 compilados e fonte Ubuntu.

Versiona só as ENTRADAS reutilizáveis (.design-sync/): config, 22 previews, conventions.md (guia do agente de design), NOTES.md, o barrel entry.ts, o tsconfig de aliases e o shim de crest.ts (contorna o import.meta.glob do Vite, que quebrava o bundle no esbuild). O bundle gerado (ds-bundle/) e o CSS compilado seguem gitignored.

Upload ainda pendente: este ambiente não tem /design-login interativo. Rodar /design-sync num terminal claude interativo reusa tudo isto e faz build + upload.